### PR TITLE
Get rid of old `is_official_example` machinery

### DIFF
--- a/crates/re_analytics/src/event.rs
+++ b/crates/re_analytics/src/event.rs
@@ -94,7 +94,6 @@ pub struct StoreInfo {
     pub python_version: Option<String>,
 
     // Whether or not the data is coming from one of the Rerun example applications.
-    pub is_official_example: bool,
     pub app_id_starts_with_rerun_example: bool,
 }
 
@@ -199,7 +198,6 @@ impl Properties for OpenRecording {
             event.insert_opt("rust_version", store_info.rust_version);
             event.insert_opt("llvm_version", store_info.llvm_version);
             event.insert_opt("python_version", store_info.python_version);
-            event.insert("is_official_example", store_info.is_official_example);
             event.insert(
                 "app_id_starts_with_rerun_example",
                 store_info.app_id_starts_with_rerun_example,

--- a/crates/re_data_source/src/load_file.rs
+++ b/crates/re_data_source/src/load_file.rs
@@ -119,7 +119,6 @@ pub(crate) fn prepare_store_info(
             info: re_log_types::StoreInfo {
                 application_id: app_id.clone(),
                 store_id: store_id.clone(),
-                is_official_example: false,
                 started: re_log_types::Time::now(),
                 store_source,
                 store_kind: re_log_types::StoreKind::Recording,

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -36,7 +36,6 @@ impl crate::DataUi for re_entity_db::EntityDb {
                 let re_log_types::StoreInfo {
                     application_id,
                     store_id: _,
-                    is_official_example: _,
                     started,
                     store_source,
                     store_kind,

--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -36,7 +36,6 @@ impl DataUi for SetStoreInfo {
             store_id,
             started,
             store_source,
-            is_official_example,
             store_kind,
         } = info;
 
@@ -55,10 +54,6 @@ impl DataUi for SetStoreInfo {
 
             ui.monospace("store_source:");
             ui.label(format!("{store_source}"));
-            ui.end_row();
-
-            ui.monospace("is_official_example:");
-            ui.label(format!("{is_official_example}"));
             ui.end_row();
 
             ui.monospace("store_kind:");

--- a/crates/re_log_encoding/src/decoder/mod.rs
+++ b/crates/re_log_encoding/src/decoder/mod.rs
@@ -232,7 +232,6 @@ fn test_encode_decode() {
         info: StoreInfo {
             application_id: ApplicationId("test".to_owned()),
             store_id: StoreId::random(StoreKind::Recording),
-            is_official_example: true,
             started: Time::now(),
             store_source: StoreSource::RustSdk {
                 rustc_version: String::new(),

--- a/crates/re_log_encoding/src/decoder/stream.rs
+++ b/crates/re_log_encoding/src/decoder/stream.rs
@@ -235,7 +235,6 @@ mod tests {
             info: StoreInfo {
                 application_id: ApplicationId::unknown(),
                 store_id: StoreId::from_string(StoreKind::Recording, "test".into()),
-                is_official_example: false,
                 started: Time::from_ns_since_epoch(0),
                 store_source: StoreSource::Unknown,
                 store_kind: StoreKind::Recording,

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -251,9 +251,6 @@ pub struct StoreInfo {
     /// Should be unique for each recording.
     pub store_id: StoreId,
 
-    /// True if the recording is one of the official Rerun examples.
-    pub is_official_example: bool,
-
     /// When the recording started.
     ///
     /// Should be an absolute time, i.e. relative to Unix Epoch.

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -167,14 +167,12 @@ pub fn decide_logging_enabled(default_enabled: bool) -> bool {
 // ----------------------------------------------------------------------------
 
 /// Creates a new [`re_log_types::StoreInfo`] which can be used with [`RecordingStream::new`].
-#[track_caller] // track_caller so that we can see if we are being called from an official example.
 pub fn new_store_info(
     application_id: impl Into<re_log_types::ApplicationId>,
 ) -> re_log_types::StoreInfo {
     re_log_types::StoreInfo {
         application_id: application_id.into(),
         store_id: StoreId::random(StoreKind::Recording),
-        is_official_example: called_from_official_rust_example(),
         started: re_log_types::Time::now(),
         store_source: re_log_types::StoreSource::RustSdk {
             rustc_version: env!("RE_BUILD_RUSTC_VERSION").into(),
@@ -182,20 +180,4 @@ pub fn new_store_info(
         },
         store_kind: re_log_types::StoreKind::Recording,
     }
-}
-
-#[track_caller]
-fn called_from_official_rust_example() -> bool {
-    // The sentinel file we use to identify the official examples directory.
-    const SENTINEL_FILENAME: &str = ".rerun_examples";
-    let caller = core::panic::Location::caller();
-    let mut path = std::path::PathBuf::from(caller.file());
-    let mut is_official_example = false;
-    for _ in 0..4 {
-        path.pop(); // first iteration is always a file path in our examples
-        if path.join(SENTINEL_FILENAME).exists() {
-            is_official_example = true;
-        }
-    }
-    is_official_example
 }

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -112,8 +112,6 @@ pub struct RecordingStreamBuilder {
     enabled: Option<bool>,
 
     batcher_config: Option<DataTableBatcherConfig>,
-
-    is_official_example: bool,
 }
 
 impl RecordingStreamBuilder {
@@ -131,7 +129,6 @@ impl RecordingStreamBuilder {
     #[track_caller]
     pub fn new(application_id: impl Into<ApplicationId>) -> Self {
         let application_id = application_id.into();
-        let is_official_example = crate::called_from_official_rust_example();
 
         Self {
             application_id,
@@ -143,7 +140,6 @@ impl RecordingStreamBuilder {
             enabled: None,
 
             batcher_config: None,
-            is_official_example,
         }
     }
 
@@ -215,14 +211,6 @@ impl RecordingStreamBuilder {
     #[inline]
     pub fn store_source(mut self, store_source: StoreSource) -> Self {
         self.store_source = Some(store_source);
-        self
-    }
-
-    #[allow(clippy::wrong_self_convention)]
-    #[doc(hidden)]
-    #[inline]
-    pub fn is_official_example(mut self, is_official_example: bool) -> Self {
-        self.is_official_example = is_official_example;
         self
     }
 
@@ -540,7 +528,6 @@ impl RecordingStreamBuilder {
             default_enabled: _,
             enabled: _,
             batcher_config,
-            is_official_example,
         } = self;
 
         let store_id = store_id.unwrap_or(StoreId::random(store_kind));
@@ -552,7 +539,6 @@ impl RecordingStreamBuilder {
         let store_info = StoreInfo {
             application_id,
             store_id,
-            is_official_example,
             started: Time::now(),
             store_source,
             store_kind,

--- a/crates/re_viewer/src/store_hub.rs
+++ b/crates/re_viewer/src/store_hub.rs
@@ -639,7 +639,6 @@ impl StoreBundle {
                 info: re_log_types::StoreInfo {
                     application_id: id.as_str().into(),
                     store_id: id.clone(),
-                    is_official_example: false,
                     started: re_log_types::Time::now(),
                     store_source: re_log_types::StoreSource::Other("viewer".to_owned()),
                     store_kind: StoreKind::Blueprint,

--- a/crates/re_viewer/src/ui/welcome_screen/welcome_section.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/welcome_section.rs
@@ -308,7 +308,6 @@ fn open_quick_start(
     let store_info = StoreInfo {
         application_id: "Quick Start".into(),
         store_id: StoreId::random(StoreKind::Recording),
-        is_official_example: true,
         started: Time::now(),
         store_source: StoreSource::Viewer,
         store_kind: StoreKind::Recording,

--- a/crates/re_viewer/src/viewer_analytics/event.rs
+++ b/crates/re_viewer/src/viewer_analytics/event.rs
@@ -44,13 +44,18 @@ pub fn open_recording(
     entity_db: &re_entity_db::EntityDb,
 ) -> OpenRecording {
     let store_info = entity_db.store_info().map(|store_info| {
-        let application_id = if store_info.is_official_example {
+        let app_id_starts_with_rerun_example = store_info
+            .application_id
+            .as_str()
+            .starts_with("rerun_example");
+
+        let application_id = if app_id_starts_with_rerun_example {
             Id::Official(store_info.application_id.0.clone())
         } else {
             Id::Hashed(Property::from(store_info.application_id.0.clone()).hashed())
         };
 
-        let recording_id = if store_info.is_official_example {
+        let recording_id = if app_id_starts_with_rerun_example {
             Id::Official(store_info.store_id.to_string())
         } else {
             Id::Hashed(Property::from(store_info.store_id.to_string()).hashed())
@@ -95,12 +100,6 @@ pub fn open_recording(
             S::CSdk | S::Unknown | S::Viewer | S::Other(_) => {}
         }
 
-        let is_official_example = store_info.is_official_example;
-        let app_id_starts_with_rerun_example = store_info
-            .application_id
-            .as_str()
-            .starts_with("rerun_example");
-
         StoreInfo {
             application_id,
             recording_id,
@@ -108,7 +107,6 @@ pub fn open_recording(
             rust_version,
             llvm_version,
             python_version,
-            is_official_example,
             app_id_starts_with_rerun_example,
         }
     });

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -294,7 +294,6 @@ fn rr_recording_stream_new_impl(
     let application_id = application_id.as_str("store_info.application_id")?;
 
     let mut rec_builder = RecordingStreamBuilder::new(application_id)
-        //.is_official_example(is_official_example) // TODO(andreas): Is there a meaningful way to expose this?
         //.store_id(recording_id.clone()) // TODO(andreas): Expose store id.
         .store_source(re_log_types::StoreSource::CSdk)
         .default_enabled(default_enabled);

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -221,19 +221,6 @@ fn new_recording(
     application_path: Option<PathBuf>,
     default_enabled: bool,
 ) -> PyResult<PyRecordingStream> {
-    // The sentinel file we use to identify the official examples directory.
-    const SENTINEL_FILENAME: &str = ".rerun_examples";
-    let is_official_example = application_path.map_or(false, |mut path| {
-        // more than 4 layers would be really pushing it
-        for _ in 0..4 {
-            path.pop(); // first iteration is always a file path in our examples
-            if path.join(SENTINEL_FILENAME).exists() {
-                return true;
-            }
-        }
-        false
-    });
-
     let recording_id = if let Some(recording_id) = recording_id {
         StoreId::from_string(StoreKind::Recording, recording_id)
     } else {
@@ -248,7 +235,6 @@ fn new_recording(
 
     let recording = RecordingStreamBuilder::new(application_id)
         .batcher_config(batcher_config)
-        .is_official_example(is_official_example)
         .store_id(recording_id.clone())
         .store_source(re_log_types::StoreSource::PythonSdk(python_version(py)))
         .default_enabled(default_enabled)


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#5415](https://togithub.com/rerun-io/rerun/pull/5415).



The original branch is upstream/cmc/delete_isofficialexample