### PR TITLE
Make rerun execution script handle .exe suffix correctly

### DIFF
--- a/.github/workflows/reusable_build_and_upload_wheels.yml
+++ b/.github/workflows/reusable_build_and_upload_wheels.yml
@@ -204,7 +204,7 @@ jobs:
           --commit-sha ${{ steps.get-sha.outputs.sha }} \
           --artifact rerun-cli \
           --platform ${{ inputs.PLATFORM }} \
-          --dest rerun_py/rerun_sdk/bin
+          --dest rerun_py/rerun_sdk/rerun_cli
 
       - name: Build
         run: |

--- a/rerun_py/.gitignore
+++ b/rerun_py/.gitignore
@@ -1,6 +1,7 @@
 !Cargo.lock
 .DS_Store
-rerun_sdk/bin/**
+rerun_sdk/rerun_cli/rerun
+rerun_sdk/rerun_cli/rerun.exe
 site/
 target/
 venv/

--- a/rerun_py/build.rs
+++ b/rerun_py/build.rs
@@ -11,10 +11,12 @@ fn main() {
         #[cfg(target_os = "windows")]
         let rerun_bin = std::env::current_dir()
             .unwrap()
-            .join("rerun_sdk/bin/rerun.exe");
+            .join("rerun_sdk/rerun_cli/rerun.exe");
 
         #[cfg(not(target_os = "windows"))]
-        let rerun_bin = std::env::current_dir().unwrap().join("rerun_sdk/bin/rerun");
+        let rerun_bin = std::env::current_dir()
+            .unwrap()
+            .join("rerun_sdk/rerun_cli/rerun");
 
         if !rerun_bin.exists() {
             eprintln!("ERROR: Expected to find `rerun` at `{rerun_bin:?}`.");

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -142,7 +142,11 @@ required-imports = ["from __future__ import annotations"]
 # Even though both `rerun` and `rerun.exe` are here, only one will be included since
 # they both should not be fetched in CI when running the build.
 # Files missing from this list is not a packaging failure.
-include = ["rerun_sdk.pth", "rerun_sdk/bin/rerun", "rerun_sdk/bin/rerun.exe"]
+include = [
+  "rerun_sdk.pth",
+  "rerun_sdk/rerun_cli/rerun",
+  "rerun_sdk/rerun_cli/rerun.exe",
+]
 locked = true
 name = "rerun_bindings"
 python-packages = ["rerun_sdk/rerun", "rerun_sdk/rerun_cli"]

--- a/rerun_py/rerun_sdk/rerun/__main__.py
+++ b/rerun_py/rerun_sdk/rerun/__main__.py
@@ -15,6 +15,18 @@ import sys
 from rerun import unregister_shutdown
 
 
+def exe_suffix() -> str:
+    if sys.platform.startswith("win"):
+        return ".exe"
+    return ""
+
+
+def add_exe_suffix(path: str) -> str:
+    if not path.endswith(exe_suffix()):
+        return path + exe_suffix()
+    return path
+
+
 def main() -> int:
     # Importing of the rerun module registers a shutdown hook that we know we don't
     # need when running the CLI directly. We can safely unregister it.
@@ -24,6 +36,8 @@ def main() -> int:
         target_path = os.environ["RERUN_CLI_PATH"]
     else:
         target_path = os.path.join(os.path.dirname(__file__), "..", "bin", "rerun")
+
+    target_path = add_exe_suffix(target_path)
 
     if not os.path.exists(target_path):
         print(f"Error: Could not find rerun binary at {target_path}", file=sys.stderr)

--- a/rerun_py/rerun_sdk/rerun/__main__.py
+++ b/rerun_py/rerun_sdk/rerun/__main__.py
@@ -35,7 +35,7 @@ def main() -> int:
         print(f"Using overridden RERUN_CLI_PATH={os.environ['RERUN_CLI_PATH']}", file=sys.stderr)
         target_path = os.environ["RERUN_CLI_PATH"]
     else:
-        target_path = os.path.join(os.path.dirname(__file__), "..", "bin", "rerun")
+        target_path = os.path.join(os.path.dirname(__file__), "..", "rerun_cli", "rerun")
 
     target_path = add_exe_suffix(target_path)
 

--- a/rerun_py/rerun_sdk/rerun/__main__.py
+++ b/rerun_py/rerun_sdk/rerun/__main__.py
@@ -8,42 +8,17 @@ importing the module.
 
 from __future__ import annotations
 
-import os
-import subprocess
-import sys
+from rerun_cli.__main__ import main as cli_main
 
 from rerun import unregister_shutdown
-
-
-def exe_suffix() -> str:
-    if sys.platform.startswith("win"):
-        return ".exe"
-    return ""
-
-
-def add_exe_suffix(path: str) -> str:
-    if not path.endswith(exe_suffix()):
-        return path + exe_suffix()
-    return path
 
 
 def main() -> int:
     # Importing of the rerun module registers a shutdown hook that we know we don't
     # need when running the CLI directly. We can safely unregister it.
     unregister_shutdown()
-    if "RERUN_CLI_PATH" in os.environ:
-        print(f"Using overridden RERUN_CLI_PATH={os.environ['RERUN_CLI_PATH']}", file=sys.stderr)
-        target_path = os.environ["RERUN_CLI_PATH"]
-    else:
-        target_path = os.path.join(os.path.dirname(__file__), "..", "rerun_cli", "rerun")
 
-    target_path = add_exe_suffix(target_path)
-
-    if not os.path.exists(target_path):
-        print(f"Error: Could not find rerun binary at {target_path}", file=sys.stderr)
-        return 1
-
-    return subprocess.call([target_path, *sys.argv[1:]])
+    return cli_main()
 
 
 if __name__ == "__main__":

--- a/rerun_py/rerun_sdk/rerun_cli/__main__.py
+++ b/rerun_py/rerun_sdk/rerun_cli/__main__.py
@@ -24,7 +24,7 @@ def main() -> int:
         print(f"Using overridden RERUN_CLI_PATH={os.environ['RERUN_CLI_PATH']}", file=sys.stderr)
         target_path = os.environ["RERUN_CLI_PATH"]
     else:
-        target_path = os.path.join(os.path.dirname(__file__), "..", "bin", "rerun")
+        target_path = os.path.join(os.path.dirname(__file__), "rerun")
 
     target_path = add_exe_suffix(target_path)
 

--- a/rerun_py/rerun_sdk/rerun_cli/__main__.py
+++ b/rerun_py/rerun_sdk/rerun_cli/__main__.py
@@ -7,12 +7,26 @@ import subprocess
 import sys
 
 
+def exe_suffix() -> str:
+    if sys.platform.startswith("win"):
+        return ".exe"
+    return ""
+
+
+def add_exe_suffix(path: str) -> str:
+    if not path.endswith(exe_suffix()):
+        return path + exe_suffix()
+    return path
+
+
 def main() -> int:
     if "RERUN_CLI_PATH" in os.environ:
         print(f"Using overridden RERUN_CLI_PATH={os.environ['RERUN_CLI_PATH']}", file=sys.stderr)
         target_path = os.environ["RERUN_CLI_PATH"]
     else:
         target_path = os.path.join(os.path.dirname(__file__), "..", "bin", "rerun")
+
+    target_path = add_exe_suffix(target_path)
 
     if not os.path.exists(target_path):
         print(f"Error: Could not find rerun binary at {target_path}", file=sys.stderr)


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6046](https://togithub.com/rerun-io/rerun/pull/6046).



The original branch is upstream/jleibs/fix_broken_win_path_check