### PR TITLE
Switch default plot aggregator from `MinMax` to `MinMaxAverage`

### DIFF
--- a/crates/re_entity_db/src/entity_properties.rs
+++ b/crates/re_entity_db/src/entity_properties.rs
@@ -370,10 +370,10 @@ pub enum TimeSeriesAggregator {
     /// Keep both the minimum and maximum values in the range.
     ///
     /// This will yield two aggregated points instead of one, effectively creating a vertical line.
-    #[default]
     MinMax,
 
     /// Find both the minimum and maximum values in the range, then use the average of those.
+    #[default] // Fast, and looks good
     MinMaxAverage,
 }
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6079](https://togithub.com/rerun-io/rerun/pull/6079).



The original branch is upstream/emilk/smoother-plots