### PR TITLE
Add new CMake target `ALL` to workaround CMake lying about built-in `all` target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,3 +178,36 @@ add_subdirectory(rerun_cpp) # The Rerun C++ SDK library.
 add_subdirectory(examples/cpp)
 add_subdirectory(tests/cpp)
 add_subdirectory(docs/snippets)
+
+# ------------------------------------------------------------------------------
+# Setup an 'all_targets' target that depends on all targets in the project.
+#
+# CMake already has an `all` (lowercase!) target as the default,
+# but it does NOT work with Visual Studio and XCode.
+# See https://cmake.org/cmake/help/latest/guide/user-interaction/index.html#selecting-a-target
+
+# Collect all currently added targets in all subdirectories
+#
+# Via: https://stackoverflow.com/a/60232044
+#
+# Parameters:
+# - _result the list containing all found targets
+# - _dir root directory to start looking from
+function(get_all_targets _result _dir)
+    get_property(_subdirs DIRECTORY "${_dir}" PROPERTY SUBDIRECTORIES)
+
+    foreach(_subdir IN LISTS _subdirs)
+        get_all_targets(${_result} "${_subdir}")
+    endforeach()
+
+    get_directory_property(_sub_targets DIRECTORY "${_dir}" BUILDSYSTEM_TARGETS)
+    set(${_result} ${${_result}} ${_sub_targets} PARENT_SCOPE)
+endfunction()
+
+get_all_targets(all_targets ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_custom_target(ALL DEPENDS ${all_targets})
+
+foreach(target IN LISTS all_targets_list)
+    add_dependencies(ALL ${target})
+endforeach()

--- a/pixi.toml
+++ b/pixi.toml
@@ -196,11 +196,11 @@ py-docs-serve = "mkdocs serve -f rerun_py/mkdocs.yml -w rerun_py"
 # All the cpp-* tasks can be configured with environment variables, e.g.: RERUN_WERROR=ON CXX=clang++
 cpp-prepare-release = "cmake -G 'Ninja' -B build/release -S . -DCMAKE_BUILD_TYPE=Release"
 cpp-prepare = "cmake -G 'Ninja' -B build/debug -S . -DCMAKE_BUILD_TYPE=Debug"
-cpp-build-all = { cmd = "cmake --build build/debug --config Debug --target all", depends_on = [
+cpp-build-all = { cmd = "cmake --build build/debug --config Debug --target ALL", depends_on = [
   "cpp-prepare",
 ] }
 cpp-prepare-shared-libs = "cmake -G 'Ninja' -B build/debug -S . -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON"
-cpp-build-all-shared-libs = { cmd = "cmake --build build/debug --config Debug --target all", depends_on = [
+cpp-build-all-shared-libs = { cmd = "cmake --build build/debug --config Debug --target ALL", depends_on = [
   "cpp-prepare-shared-libs",
 ] }
 cpp-clean = "rm -rf build CMakeCache.txt CMakeFiles"

--- a/rerun_cpp/src/rerun/c/rerun.h
+++ b/rerun_cpp/src/rerun/c/rerun.h
@@ -268,7 +268,7 @@ typedef struct rr_error {
 ///
 /// This should match the string returned by `rr_version_string`.
 /// If not, the SDK's binary and the C header are out of sync.
-#define RERUN_SDK_HEADER_VERSION "0.16.0-alpha.1+dev"
+#define RERUN_SDK_HEADER_VERSION "0.16.0-alpha.2"
 
 /// Returns a human-readable version string of the Rerun C SDK.
 ///


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6091](https://togithub.com/rerun-io/rerun/pull/6091).



The original branch is upstream/andreas/fix-cmake-all-target