### PR TITLE
Add `TextDocument::from_markdown` constructor

### DIFF
--- a/crates/re_types/src/archetypes/text_document.rs
+++ b/crates/re_types/src/archetypes/text_document.rs
@@ -40,7 +40,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     rec.log(
 ///         "markdown",
-///         &rerun::TextDocument::new(
+///         &rerun::TextDocument::from_markdown(
 ///             r#"
 /// # Hello Markdown!
 /// [Click here to see the raw text](recording://markdown:Text).
@@ -77,7 +77,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ![A random image](https://picsum.photos/640/480)
 /// "#.trim(),
 ///         )
-///         .with_media_type(rerun::MediaType::markdown()),
 ///     )?;
 ///
 ///     Ok(())

--- a/crates/re_types/src/archetypes/text_document_ext.rs
+++ b/crates/re_types/src/archetypes/text_document_ext.rs
@@ -32,4 +32,12 @@ impl TextDocument {
             media_type,
         })
     }
+
+    /// Creates a new [`TextDocument`] containing Markdown.
+    ///
+    /// Equivalent to `TextDocument::new(markdown).with_media_type(MediaType::markdown())`.
+    #[inline]
+    pub fn from_markdown(markdown: impl Into<crate::components::Text>) -> Self {
+        Self::new(markdown).with_media_type(MediaType::markdown())
+    }
 }

--- a/docs/snippets/all/text_document.rs
+++ b/docs/snippets/all/text_document.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     rec.log(
         "markdown",
-        &rerun::TextDocument::new(
+        &rerun::TextDocument::from_markdown(
             r#"
 # Hello Markdown!
 [Click here to see the raw text](recording://markdown:Text).
@@ -47,7 +47,6 @@ Of course you can also have [normal https links](https://github.com/rerun-io/rer
 ![A random image](https://picsum.photos/640/480)
 "#.trim(),
         )
-        .with_media_type(rerun::MediaType::markdown()),
     )?;
 
     Ok(())

--- a/examples/rust/external_data_loader/src/main.rs
+++ b/examples/rust/external_data_loader/src/main.rs
@@ -106,7 +106,7 @@ fn main() -> anyhow::Result<()> {
     rec.log_with_static(
         entity_path_prefix.join(&rerun::EntityPath::from_file_path(&args.filepath)),
         args.statically || args.timeless,
-        &rerun::TextDocument::new(text).with_media_type(MediaType::MARKDOWN),
+        &rerun::TextDocument::from_markdown(text),
     )?;
 
     Ok::<_, anyhow::Error>(())

--- a/examples/rust/external_data_loader/src/main.rs
+++ b/examples/rust/external_data_loader/src/main.rs
@@ -1,6 +1,6 @@
 //! Example of an external data-loader executable plugin for the Rerun Viewer.
 
-use rerun::{MediaType, EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE};
+use rerun::EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE;
 
 // The Rerun Viewer will always pass at least these two pieces of information:
 // 1. The path to be loaded, as a positional arg.

--- a/examples/rust/incremental_logging/src/main.rs
+++ b/examples/rust/incremental_logging/src/main.rs
@@ -56,10 +56,7 @@ Move the time cursor around, and notice how the colors and radii from frame 0 ar
 "#;
 
 fn run(rec: &rerun::RecordingStream) -> anyhow::Result<()> {
-    rec.log_static(
-        "readme",
-        &rerun::TextDocument::new(README).with_media_type(rerun::MediaType::MARKDOWN),
-    )?;
+    rec.log_static("readme", &rerun::TextDocument::from_markdown(README))?;
 
     // TODO(#5264): just log one once clamp-to-edge semantics land.
     let colors = [rerun::Color::from_rgb(255, 0, 0); 10];

--- a/tests/rust/roundtrips/text_document/src/main.rs
+++ b/tests/rust/roundtrips/text_document/src/main.rs
@@ -1,10 +1,6 @@
 //! Logs a `Tensor` archetype for roundtrip checks.
 
-use rerun::{
-    archetypes::TextDocument,
-    external::{re_log, re_types::components::MediaType},
-    RecordingStream,
-};
+use rerun::{archetypes::TextDocument, external::re_log, RecordingStream};
 
 #[derive(Debug, clap::Parser)]
 #[clap(author, version, about)]

--- a/tests/rust/roundtrips/text_document/src/main.rs
+++ b/tests/rust/roundtrips/text_document/src/main.rs
@@ -17,15 +17,14 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
     rec.log("text_document", &TextDocument::new("Hello, TextDocument!"))?;
     rec.log(
         "markdown",
-        &TextDocument::new(
+        &TextDocument::from_markdown(
             "# Hello\n\
              Markdown with `code`!\n\
              \n\
              A random image:\n\
              \n\
              ![A random image](https://picsum.photos/640/480)",
-        )
-        .with_media_type(MediaType::markdown()),
+        ),
     )?;
     Ok(())
 }

--- a/tests/rust/test_pinhole_projection/src/main.rs
+++ b/tests/rust/test_pinhole_projection/src/main.rs
@@ -4,7 +4,7 @@
 //! cargo run -p test_pinhole_projection
 //! ```
 
-use rerun::{external::re_log, MediaType, RecordingStream};
+use rerun::{external::re_log, RecordingStream};
 
 #[derive(Debug, clap::Parser)]
 #[clap(author, version, about)]

--- a/tests/rust/test_pinhole_projection/src/main.rs
+++ b/tests/rust/test_pinhole_projection/src/main.rs
@@ -31,7 +31,7 @@ fn run(rec: &RecordingStream) -> anyhow::Result<()> {
     ";
     rec.log_static(
         "description",
-        &rerun::TextDocument::new(DESCRIPTION).with_media_type(MediaType::markdown()),
+        &rerun::TextDocument::from_markdown(DESCRIPTION),
     )?;
 
     rec.log_static("world", &rerun::ViewCoordinates::RIGHT_HAND_Y_DOWN)?;


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6109](https://togithub.com/rerun-io/rerun/pull/6109).



The original branch is upstream/emilk/from_markdown