### PR TITLE
Fix `pixi run fast-lint`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -116,7 +116,7 @@ fmt = { depends_on = ["format"] }
 # Assorted linting tasks
 fast-lint = "python scripts/fast_lint.py"
 lint-codegen = "cargo --quiet run --package re_types_builder -- --check"
-# TODO(jleibs): implement lint-cpp-all
+# TODO(jleibs): implement lint-cpp-files
 lint-rerun = "python scripts/lint.py"
 lint-rs-files = "rustfmt --edition 2021 --check"
 lint-rs-all = "cargo fmt --check"

--- a/scripts/fast_lint.py
+++ b/scripts/fast_lint.py
@@ -139,11 +139,12 @@ def main() -> None:
 
     jobs = [
         LintJob("lint-codegen", accepts_files=False),
-        LintJob(
-            "lint-cpp-files",
-            extensions=[".cpp", ".c", ".h", ".hpp"],
-            allow_no_filter=False,
-        ),
+        # TODO(jleibs): implement lint-cpp-files
+        # LintJob(
+        #     "lint-cpp-files",
+        #     extensions=[".cpp", ".c", ".h", ".hpp"],
+        #     allow_no_filter=False,
+        # ),
         LintJob("lint-rerun"),
         LintJob(
             "lint-rs-files",


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6119](https://togithub.com/rerun-io/rerun/pull/6119).



The original branch is upstream/cmc/fix_fast_lint