### PR TITLE
Make visible time range ui aware of latest-at & `QueryRange`

### DIFF
--- a/crates/re_types_core/src/datatypes/visible_time_range_ext.rs
+++ b/crates/re_types_core/src/datatypes/visible_time_range_ext.rs
@@ -9,4 +9,13 @@ impl VisibleTimeRange {
         // This means +∞
         end: VisibleTimeRangeBoundary::INFINITE,
     };
+
+    /// A range of zero length exactly at the time cursor.
+    ///
+    /// This is *not* the same as latest-at queries and queries the state that was logged exactly at the cursor.
+    /// In contrast, latest-at queries each component's latest known state.
+    pub const AT_CURSOR: Self = Self {
+        start: VisibleTimeRangeBoundary::AT_CURSOR,
+        end: VisibleTimeRangeBoundary::AT_CURSOR,
+    };
 }

--- a/crates/re_viewer/src/ui/mod.rs
+++ b/crates/re_viewer/src/ui/mod.rs
@@ -8,9 +8,9 @@ mod top_panel;
 mod welcome_screen;
 
 pub(crate) mod memory_panel;
+pub(crate) mod query_range_ui;
 pub(crate) mod selection_panel;
 pub(crate) mod space_view_space_origin_ui;
-pub(crate) mod visual_time_range;
 
 pub use blueprint_panel::blueprint_panel_ui;
 pub use recordings_panel::recordings_panel_ui;

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -29,8 +29,8 @@ use crate::ui::override_ui::override_visualizer_ui;
 use crate::{app_state::default_selection_panel_width, ui::override_ui::override_ui};
 
 use super::{
-    selection_history_ui::SelectionHistoryUi, visual_time_range::visual_time_range_ui_data_result,
-    visual_time_range::visual_time_range_ui_space_view,
+    query_range_ui::query_range_ui_data_result, query_range_ui::query_range_ui_space_view,
+    selection_history_ui::SelectionHistoryUi,
 };
 
 // ---
@@ -904,7 +904,7 @@ fn blueprint_ui_for_space_view(
             &class_identifier,
         );
 
-        visual_time_range_ui_space_view(ctx, ui, space_view);
+        query_range_ui_space_view(ctx, ui, space_view);
 
         // Space View don't inherit (legacy) properties.
         let mut props =
@@ -1174,7 +1174,7 @@ fn entity_props_ui(
         .checkbox(ui, &mut entity_props.interactive, "Interactive")
         .on_hover_text("If disabled, the entity will not react to any mouse interaction");
 
-    visual_time_range_ui_data_result(ctx, ui, &query_result.tree, data_result);
+    query_range_ui_data_result(ctx, ui, &query_result.tree, data_result);
 
     egui::Grid::new("entity_properties")
         .num_columns(2)


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6176](https://togithub.com/rerun-io/rerun/pull/6176).



The original branch is upstream/andreas/improve-visible-time-range-ui-messages