### PR TITLE
Add button to equalize the size of the children of a container

### DIFF
--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -741,7 +741,7 @@ fn container_top_level_properties(
                 && ui
                     .add_enabled(
                         !all_shares_are_equal,
-                        egui::Button::new("Equalize children"),
+                        egui::Button::new("Distribute content equally"),
                     )
                     .on_hover_text("Make all children the same size")
                     .clicked()

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -720,6 +720,35 @@ fn container_top_level_properties(
                     },
                 );
             }
+            ui.end_row();
+
+            // ---
+
+            fn equal_shares(shares: &[f32]) -> bool {
+                shares.iter().all(|&share| share == shares[0])
+            }
+
+            let all_shares_are_equal =
+                equal_shares(&container.col_shares) && equal_shares(&container.row_shares);
+
+            if container.contents.len() > 1
+                && match container.container_kind {
+                    egui_tiles::ContainerKind::Tabs => false,
+                    egui_tiles::ContainerKind::Horizontal
+                    | egui_tiles::ContainerKind::Vertical
+                    | egui_tiles::ContainerKind::Grid => true,
+                }
+                && ui
+                    .add_enabled(
+                        !all_shares_are_equal,
+                        egui::Button::new("Equalize children"),
+                    )
+                    .on_hover_text("Make all children the same size")
+                    .clicked()
+            {
+                viewport.blueprint.make_all_children_same_size(container_id);
+            }
+            ui.end_row();
         });
 }
 

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -673,6 +673,11 @@ impl ViewportBlueprint {
         ));
     }
 
+    /// Make all children of the given container the same size.
+    pub fn make_all_children_same_size(&self, container_id: &ContainerId) {
+        self.send_tree_action(TreeAction::MakeAllChildrenSameSize(*container_id));
+    }
+
     /// Set the container that is currently identified as the drop target of an ongoing drag.
     ///
     /// This is used for highlighting the drop target in the UI. Note that the drop target container is reset at every


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6194](https://togithub.com/rerun-io/rerun/pull/6194).



The original branch is upstream/emilk/equalize-children