### PR TITLE
Fix out-of-bounds crash in origin selection popup

### DIFF
--- a/crates/re_viewer/src/ui/space_view_space_origin_ui.rs
+++ b/crates/re_viewer/src/ui/space_view_space_origin_ui.rs
@@ -144,9 +144,11 @@ fn space_view_space_origin_widget_editing_ui(
 
     if let Some(selected_suggestion) = state.selected_suggestion {
         if enter_key_hit {
-            let origin = &filtered_space_view_suggestions[selected_suggestion].space_origin;
-            state.origin_string = origin.to_string();
-            control_flow = ControlFlow::Break(Some(origin.clone()));
+            if let Some(suggestion) = filtered_space_view_suggestions.get(selected_suggestion) {
+                let origin = &suggestion.space_origin;
+                state.origin_string = origin.to_string();
+                control_flow = ControlFlow::Break(Some(origin.clone()));
+            }
         }
     }
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6202](https://togithub.com/rerun-io/rerun/pull/6202).



The original branch is upstream/emilk/fix-out-of-bounds-crash