### PR TITLE
Use thousands separators when formatting seconds

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -7,7 +7,6 @@ extend-exclude = [
   ".typos.toml",
   "crates/re_ui/data/design_tokens.json",
   "crates/re_ui/src/design_tokens.rs",
-  "docs/cspell.json",
   "examples/assets",
   "rerun_cpp/src/rerun/third_party/cxxopts.hpp",
 ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,43 +8,6 @@
     "files.autoGuessEncoding": true,
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
-    "cSpell.ignorePaths": [
-        ".vscode",
-        "pixi.lock"
-    ],
-    "cSpell.words": [
-        "andreas",
-        "bbox",
-        "bindgroup",
-        "colormap",
-        "emath",
-        "flatbuffers",
-        "framebuffer",
-        "Frazzoli",
-        "hoverable",
-        "ilog",
-        "jumpflooding",
-        "Karaman",
-        "Keypoint",
-        "memoffset",
-        "nyud",
-        "objectron",
-        "Readback",
-        "readbacks",
-        "Skybox",
-        "smallvec",
-        "swapchain",
-        "texcoord",
-        "texcoords",
-        "Tonemapper",
-        "tonemapping",
-        "unsmoothed",
-        "visualizable",
-        "visualizability",
-        "voronoi",
-        "vram",
-        "Wgsl"
-    ],
     // don't share a cargo lock with rust-analyzer.
     // see https://github.com/rerun-io/rerun/pull/519 for rationale
     "rust-analyzer.check.overrideCommand": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,7 +214,7 @@ Blueprints are currently only supported in the Python API, with C++ and Rust sup
 This release is identical to 0.14.0 and merely fixes an issue in the build artifacts for C++:
 0.14.0 only contained binaries for Linux x64, this release has the full set for Linux x64, Windows x64, Mac x64 & Mac Arm64.
 
-## [0.14.0](https://github.com/rerun-io/rerun/compare/0.13.0...0.14.0) - "Unlimited" point clouds & lines, quality of life improvements, bugfixes - 2024-02-28
+
 ## [0.14.0](https://github.com/rerun-io/rerun/compare/0.13.0...0.14.0) - "Unlimited" point clouds & lines, quality of life improvements, bugfixes - 2024-02-28
 
 ### ✨ Overview & highlights

--- a/crates/re_log_types/src/time.rs
+++ b/crates/re_log_types/src/time.rs
@@ -132,11 +132,11 @@ impl Time {
             let secs = nanos_since_epoch as f64 * 1e-9;
 
             let is_whole_second = nanos_since_epoch % 1_000_000_000 == 0;
-            if is_whole_second {
-                format!("{secs:+.0}s")
-            } else {
-                format!("{secs:+.3}s")
-            }
+
+            let secs = re_format::FloatFormatOptions::DEFAULT_f64
+                .with_decimals(if is_whole_second { 0 } else { 3 })
+                .format(secs);
+            format!("{secs}s")
         }
     }
 

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1518,7 +1518,7 @@ impl RecordingStream {
         flush_timeout: Option<std::time::Duration>,
     ) {
         if forced_sink_path().is_some() {
-            re_log::debug!("Ignored setting new TcpSink since _RERUN_FORCE_SINK is set");
+            re_log::debug!("Ignored setting new TcpSink since {ENV_FORCE_SAVE} is set");
             return;
         }
 
@@ -1571,7 +1571,7 @@ impl RecordingStream {
             return Ok(());
         }
         if forced_sink_path().is_some() {
-            re_log::debug!("Ignored setting new TcpSink since _RERUN_FORCE_SINK is set");
+            re_log::debug!("Ignored setting new TcpSink since {ENV_FORCE_SAVE} is set");
             return Ok(());
         }
 
@@ -1620,7 +1620,7 @@ impl RecordingStream {
         path: impl Into<std::path::PathBuf>,
     ) -> Result<(), crate::sink::FileSinkError> {
         if forced_sink_path().is_some() {
-            re_log::debug!("Ignored setting new file since _RERUN_FORCE_SINK is set");
+            re_log::debug!("Ignored setting new file since {ENV_FORCE_SAVE} is set");
             return Ok(());
         }
 
@@ -1656,7 +1656,7 @@ impl RecordingStream {
     /// Blueprints are currently an experimental part of the Rust SDK.
     pub fn stdout_opts(&self) -> Result<(), crate::sink::FileSinkError> {
         if forced_sink_path().is_some() {
-            re_log::debug!("Ignored setting new file since _RERUN_FORCE_SINK is set");
+            re_log::debug!("Ignored setting new file since {ENV_FORCE_SAVE} is set");
             return Ok(());
         }
 

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -655,6 +655,8 @@ fn quote_enum(
             }
         }
 
+        // We implement `Display` to match the `PascalCase` name so that
+        // the enum variants are displayed in the UI exactly how they are displayed in code.
         impl std::fmt::Display for #name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 match self {


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6212](https://togithub.com/rerun-io/rerun/pull/6212).



The original branch is upstream/emilk/misc