### PR TITLE
Add a migration guide from 0.15 to 0.16

### DIFF
--- a/docs/content/reference/migration.md
+++ b/docs/content/reference/migration.md
@@ -1,5 +1,5 @@
 ---
 title: Migration Guides
 order: 900
-redirect: reference/migration/migration-0-15
+redirect: reference/migration/migration-0-16
 ---

--- a/docs/content/reference/migration/migration-0-16.md
+++ b/docs/content/reference/migration/migration-0-16.md
@@ -5,43 +5,48 @@ order: 160
 
 
 ## `timeless` replaced by `static`
+
 The concept of _timeless_ data has been replaced by _static_ data.
-Except for the name change, it is mostly the same.
+Except for the name change, they behave similarly in most use cases.
 
 Static data is data that shows up at all times, on all timelines.
 
-In 0.15 you could log a component as timeless once, and then change it to be temporal (non-timeless) later (or the other way around). This is no longer allowed for static data.
-Now, once you log something (a specific component on a specific entity) as static, it must stay static forever.
-Conversely, if you log something as temporal (non-static), it must not be logged as static in the future.
+In 0.15, you could log component data to the same entity path using both timeless and temporal data, and the resulting component data would end up being the concatenation of the two.
+
+0.16 introduces static data, which has a far simpler model: if you log static component data to an entity path, it unconditionally overrides any other data (whether static or temporal) for that component.
+Once static data has been logged, it can only be overwritten by other static data.
 
 Static data is most often used for `AnnotationContext` and `ViewCoordinates`.
 
 
 #### C++
+
 ```diff
 - rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP);
 + rec.log_static("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP);
 ```
 
 #### Python
+
 ```diff
 - rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)
 + rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
 ```
 
 #### Rust
+
 ```diff
 - rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?;
 + rec.log_static("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?;
 ```
 
 
-
-
 ## `MeshProperties` replaced by `TriangleIndices`
-In PR [#6169](https://github.com/rerun-io/rerun/pull/6169) we replaced `MeshProperties` with `TriangleIndices`. We could do this thanks to simplifcations in our data model.
+
+In PR [#6169](https://github.com/rerun-io/rerun/pull/6169) we replaced `MeshProperties` with `TriangleIndices`. We could do this thanks to simplifications in our data model.
 
 #### C++
+
 ```diff
   rerun::Mesh3D(positions)
 -     .with_mesh_properties(rerun::components::MeshProperties::from_triangle_indices({{2, 1, 0}}))
@@ -49,6 +54,7 @@ In PR [#6169](https://github.com/rerun-io/rerun/pull/6169) we replaced `MeshProp
 ```
 
 #### Python
+
 ```diff
   rr.Mesh3D(
       vertex_positions=…,
@@ -58,6 +64,7 @@ In PR [#6169](https://github.com/rerun-io/rerun/pull/6169) we replaced `MeshProp
 ```
 
 #### Rust
+
 ```diff
   rerun::Mesh3D::new(positions)
 -     .with_mesh_properties(rerun::MeshProperties::from_triangle_indices([[2, 1, 0]]))

--- a/docs/content/reference/migration/migration-0-16.md
+++ b/docs/content/reference/migration/migration-0-16.md
@@ -1,0 +1,65 @@
+---
+title: Migrating from 0.15 to 0.16
+order: 160
+---
+
+
+## `timeless` replaced by `static`
+The concept of _timeless_ data has been replaced by _static_ data.
+Except for the name change, it is mostly the same.
+
+Static data is data that shows up at all times, on all timelines.
+
+In 0.15 you could log a component as timeless once, and then change it to be temporal (non-timeless) later (or the other way around). This is no longer allowed for static data.
+Now, once you log something (a specific component on a specific entity) as static, it must stay static forever.
+Conversely, if you log something as temporal (non-static), it must not be logged as static in the future.
+
+Static data is most often used for `AnnotationContext` and `ViewCoordinates`.
+
+
+#### C++
+```diff
+- rec.log_timeless("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP);
++ rec.log_static("world", rerun::ViewCoordinates::RIGHT_HAND_Z_UP);
+```
+
+#### Python
+```diff
+- rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)
++ rr.log("world", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
+```
+
+#### Rust
+```diff
+- rec.log_timeless("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?;
++ rec.log_static("world", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?;
+```
+
+
+
+
+## `MeshProperties` replaced by `TriangleIndices`
+In PR [#6169](https://github.com/rerun-io/rerun/pull/6169) we replaced `MeshProperties` with `TriangleIndices`. We could do this thanks to simplifcations in our data model.
+
+#### C++
+```diff
+  rerun::Mesh3D(positions)
+-     .with_mesh_properties(rerun::components::MeshProperties::from_triangle_indices({{2, 1, 0}}))
++     .with_triangle_indices({{2, 1, 0}})
+```
+
+#### Python
+```diff
+  rr.Mesh3D(
+      vertex_positions=…,
+-     indices=[2, 1, 0],
++     triangle_indices=[2, 1, 0],
+  ),
+```
+
+#### Rust
+```diff
+  rerun::Mesh3D::new(positions)
+-     .with_mesh_properties(rerun::MeshProperties::from_triangle_indices([[2, 1, 0]]))
++     .with_triangle_indices([[2, 1, 0]])
+```


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6233](https://togithub.com/rerun-io/rerun/pull/6233).



The original branch is upstream/emilk/0-16-migration-guide