### PR TITLE
Fix issue with the `thread_local_stream` leaking context

### DIFF
--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -306,6 +306,8 @@ SECTION_TABLE: Final[list[Section]] = [
             "start_web_viewer_server",
             "escape_entity_path_part",
             "new_entity_path",
+            "thread_local_stream",
+            "recording_stream_generator_ctx",
         ],
         class_list=["RecordingStream", "LoggingHandler", "MemoryRecording"],
     ),

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -87,6 +87,7 @@ from .recording_stream import (
     get_thread_local_data_recording,
     is_enabled,
     new_recording,
+    recording_stream_generator_ctx,
     set_global_data_recording,
     set_thread_local_data_recording,
     thread_local_stream,

--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -165,9 +165,10 @@ class RecordingStream:
     with rec:
         rr.log(...)
     ```
-    WARNING: if using a RecordingStream as a context manager, you cannot yield from a generator function
-    while holding the context. This will leak the context and likely cause your program to send data
-    to the wrong stream. See: https://github.com/rerun-io/rerun/issues/6238
+    WARNING: if using a RecordingStream as a context manager, yielding from a generator function
+    while holding the context open will leak the context and likely cause your program to send data
+    to the wrong stream. See: https://github.com/rerun-io/rerun/issues/6238. You can work around this
+    by using the [`rerun.recording_stream_generator_ctx`][] decorator.
 
     See also: [`rerun.get_data_recording`][], [`rerun.get_global_data_recording`][],
     [`rerun.get_thread_local_data_recording`][].


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6240](https://togithub.com/rerun-io/rerun/pull/6240).



The original branch is upstream/jleibs/stream_context_generators