### PR TITLE
Migrate all full-span widgets to `re_ui::full_span`

### DIFF
--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -437,9 +437,8 @@ impl<'a> ListItem<'a> {
         let (rect, mut response) = ui.allocate_at_least(desired_size, sense);
 
         // compute the full-span background rect
-        let mut bg_rect = rect;
-        bg_rect.extend_with_x(ui.clip_rect().right());
-        bg_rect.extend_with_x(ui.clip_rect().left());
+        let bg_rect =
+            egui::Rect::from_x_y_ranges(crate::full_span::get_full_span(ui), rect.y_range());
 
         // we want to be able to select/hover the item across its full span, so we sense that and
         // update the response accordingly.

--- a/crates/re_ui/src/modal.rs
+++ b/crates/re_ui/src/modal.rs
@@ -202,38 +202,40 @@ impl Modal {
             let item_spacing_y = ui.spacing().item_spacing.y;
             ui.spacing_mut().item_spacing.y = 0.0;
 
-            egui::Frame {
-                inner_margin: egui::Margin::symmetric(ReUi::view_padding(), 0.0),
-                ..Default::default()
-            }
-            .show(ui, |ui| {
-                ui.add_space(ReUi::view_padding());
-                Self::title_bar(re_ui, ui, &self.title, &mut open);
-                ui.add_space(ReUi::view_padding());
-                crate::ReUi::full_span_separator(ui);
-
-                if self.full_span_content {
-                    // no further spacing for the content UI
-                    content_ui(re_ui, ui, &mut open)
-                } else {
-                    // we must restore vertical spacing and add view padding at the bottom
-                    ui.add_space(item_spacing_y);
-
-                    egui::Frame {
-                        inner_margin: egui::Margin {
-                            bottom: ReUi::view_padding(),
-                            ..Default::default()
-                        },
-                        ..Default::default()
-                    }
-                    .show(ui, |ui| {
-                        ui.spacing_mut().item_spacing.y = item_spacing_y;
-                        content_ui(re_ui, ui, &mut open)
-                    })
-                    .inner
+            crate::full_span::full_span_scope(ui, ui.clip_rect().x_range(), |ui| {
+                egui::Frame {
+                    inner_margin: egui::Margin::symmetric(ReUi::view_padding(), 0.0),
+                    ..Default::default()
                 }
+                .show(ui, |ui| {
+                    ui.add_space(ReUi::view_padding());
+                    Self::title_bar(re_ui, ui, &self.title, &mut open);
+                    ui.add_space(ReUi::view_padding());
+                    crate::ReUi::full_span_separator(ui);
+
+                    if self.full_span_content {
+                        // no further spacing for the content UI
+                        content_ui(re_ui, ui, &mut open)
+                    } else {
+                        // we must restore vertical spacing and add view padding at the bottom
+                        ui.add_space(item_spacing_y);
+
+                        egui::Frame {
+                            inner_margin: egui::Margin {
+                                bottom: ReUi::view_padding(),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        }
+                        .show(ui, |ui| {
+                            ui.spacing_mut().item_spacing.y = item_spacing_y;
+                            content_ui(re_ui, ui, &mut open)
+                        })
+                        .inner
+                    }
+                })
+                .inner
             })
-            .inner
         });
 
         // Any click outside causes the window to close.

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -354,26 +354,23 @@ impl AppState {
                     ui,
                     app_blueprint.blueprint_panel_expanded,
                     |ui: &mut egui::Ui| {
-                        // Set the clip rectangle to the panel for the benefit of nested, "full span" widgets like
-                        // large collapsing headers. Here, no need to extend `ui.max_rect()` as the enclosing frame
-                        // doesn't have inner margins.
-                        ui.set_clip_rect(ui.max_rect());
+                        re_ui::full_span::full_span_scope(ui, ui.max_rect().x_range(), |ui| {
+                            // ListItem don't need vertical spacing so we disable it, but restore it
+                            // before drawing the blueprint panel.
+                            ui.spacing_mut().item_spacing.y = 0.0;
 
-                        // ListItem don't need vertical spacing so we disable it, but restore it
-                        // before drawing the blueprint panel.
-                        ui.spacing_mut().item_spacing.y = 0.0;
+                            let pre_cursor = ui.cursor();
+                            recordings_panel_ui(&ctx, rx, ui);
+                            let any_recording_shows = pre_cursor == ui.cursor();
 
-                        let pre_cursor = ui.cursor();
-                        recordings_panel_ui(&ctx, rx, ui);
-                        let any_recording_shows = pre_cursor == ui.cursor();
+                            if any_recording_shows {
+                                ui.add_space(4.0);
+                            }
 
-                        if any_recording_shows {
-                            ui.add_space(4.0);
-                        }
-
-                        if !show_welcome {
-                            blueprint_panel_ui(&mut viewport, &ctx, ui);
-                        }
+                            if !show_welcome {
+                                blueprint_panel_ui(&mut viewport, &ctx, ui);
+                            }
+                        });
                     },
                 );
 

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -67,11 +67,6 @@ impl SelectionPanel {
         ctx.rec_cfg.time_ctrl.write().highlighted_range = None;
 
         panel.show_animated_inside(ui, expanded, |ui: &mut egui::Ui| {
-            // Set the clip rectangle to the panel for the benefit of nested, "full span" widgets
-            // like large collapsing headers. Here, no need to extend `ui.max_rect()` as the
-            // enclosing frame doesn't have inner margins.
-            ui.set_clip_rect(ui.max_rect());
-
             re_ui::full_span::full_span_scope(ui, ui.max_rect().x_range(), |ui| {
                 ctx.re_ui.panel_content(ui, |_, ui| {
                     let hover = "The Selection View contains information and options about \
@@ -240,17 +235,15 @@ fn container_children(
         ..Default::default()
     }
     .show(ui, |ui| {
-        let clip_rect = ui.clip_rect();
-        ui.set_clip_rect(ui.max_rect());
-        ui.spacing_mut().item_spacing.y = 0.0;
+        re_ui::full_span::full_span_scope(ui, ui.max_rect().x_range(), |ui| {
+            ui.spacing_mut().item_spacing.y = 0.0;
 
-        egui::Frame {
-            inner_margin: egui::Margin::symmetric(4.0, 0.0),
-            ..Default::default()
-        }
-        .show(ui, show_content);
-
-        ui.set_clip_rect(clip_rect);
+            egui::Frame {
+                inner_margin: egui::Margin::symmetric(4.0, 0.0),
+                ..Default::default()
+            }
+            .show(ui, show_content);
+        });
     });
 }
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6248](https://togithub.com/rerun-io/rerun/pull/6248).



The original branch is upstream/antoine/full-span-migration