### PR TITLE
Rename `UiVerbosity` to `UiContext` and make its variants more precise

### DIFF
--- a/crates/re_data_ui/src/annotation_context.rs
+++ b/crates/re_data_ui/src/annotation_context.rs
@@ -5,16 +5,16 @@ use re_types::components::AnnotationContext;
 use re_types::datatypes::{
     AnnotationInfo, ClassDescription, ClassDescriptionMapElem, KeypointId, KeypointPair,
 };
-use re_viewer_context::{auto_color, UiVerbosity, ViewerContext};
+use re_viewer_context::{auto_color, UiContext, ViewerContext};
 
-use super::{table_for_verbosity, DataUi};
+use super::{table_for_ui_context, DataUi};
 
 impl crate::EntityDataUi for re_types::components::ClassId {
     fn entity_data_ui(
         &self,
-        ctx: &re_viewer_context::ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: re_viewer_context::UiVerbosity,
+        ui_context: UiContext,
         entity_path: &re_log_types::EntityPath,
         query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
@@ -34,21 +34,21 @@ impl crate::EntityDataUi for re_types::components::ClassId {
             });
 
             let id = self.0;
-            match verbosity {
-                UiVerbosity::List => {
+            match ui_context {
+                UiContext::List => {
                     if !class.keypoint_connections.is_empty()
                         || !class.keypoint_annotations.is_empty()
                     {
                         response.response.on_hover_ui(|ui| {
-                            class_description_ui(ctx, ui, verbosity, class, id);
+                            class_description_ui(ctx, ui, ui_context, class, id);
                         });
                     }
                 }
-                UiVerbosity::Tooltip
-                | UiVerbosity::SelectionPanelFull
-                | UiVerbosity::SelectionPanelLimitHeight => {
+                UiContext::Tooltip
+                | UiContext::SelectionPanelFull
+                | UiContext::SelectionPanelLimitHeight => {
                     ui.separator();
-                    class_description_ui(ctx, ui, verbosity, class, id);
+                    class_description_ui(ctx, ui, ui_context, class, id);
                 }
             }
         } else {
@@ -60,9 +60,9 @@ impl crate::EntityDataUi for re_types::components::ClassId {
 impl crate::EntityDataUi for re_types::components::KeypointId {
     fn entity_data_ui(
         &self,
-        ctx: &re_viewer_context::ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _verbosity: re_viewer_context::UiVerbosity,
+        _ui_context: UiContext,
         entity_path: &re_log_types::EntityPath,
         query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
@@ -102,12 +102,12 @@ impl DataUi for AnnotationContext {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        match verbosity {
-            UiVerbosity::List | UiVerbosity::Tooltip => {
+        match ui_context {
+            UiContext::List | UiContext::Tooltip => {
                 if self.0.len() == 1 {
                     let descr = &self.0[0].class_description;
                     ui.label(format!(
@@ -119,7 +119,7 @@ impl DataUi for AnnotationContext {
                     ui.label(format!("{} classes", self.0.len()));
                 }
             }
-            UiVerbosity::SelectionPanelLimitHeight | UiVerbosity::SelectionPanelFull => {
+            UiContext::SelectionPanelLimitHeight | UiContext::SelectionPanelFull => {
                 ui.vertical(|ui| {
                     ctx.re_ui
                         .maybe_collapsing_header(ui, true, "Classes", true, |ui| {
@@ -129,7 +129,7 @@ impl DataUi for AnnotationContext {
                                 .map(|class| &class.class_description.info)
                                 .sorted_by_key(|info| info.id)
                                 .collect_vec();
-                            annotation_info_table_ui(ui, verbosity, &annotation_infos);
+                            annotation_info_table_ui(ui, ui_context, &annotation_infos);
                         });
 
                     for ClassDescriptionMapElem {
@@ -137,7 +137,7 @@ impl DataUi for AnnotationContext {
                         class_description,
                     } in &self.0
                     {
-                        class_description_ui(ctx, ui, verbosity, class_description, *class_id);
+                        class_description_ui(ctx, ui, ui_context, class_description, *class_id);
                     }
                 });
             }
@@ -148,7 +148,7 @@ impl DataUi for AnnotationContext {
 fn class_description_ui(
     ctx: &re_viewer_context::ViewerContext<'_>,
     ui: &mut egui::Ui,
-    mut verbosity: UiVerbosity,
+    mut ui_context: UiContext,
     class: &ClassDescription,
     id: re_types::datatypes::ClassId,
 ) {
@@ -158,13 +158,13 @@ fn class_description_ui(
 
     re_tracing::profile_function!();
 
-    let use_collapsible = verbosity == UiVerbosity::SelectionPanelLimitHeight
-        || verbosity == UiVerbosity::SelectionPanelFull;
+    let use_collapsible = ui_context == UiContext::SelectionPanelLimitHeight
+        || ui_context == UiContext::SelectionPanelFull;
 
     // We use collapsible header as a means for the user to limit the height, so the annotation info
     // tables can be fully unrolled.
-    if verbosity == UiVerbosity::SelectionPanelLimitHeight {
-        verbosity = UiVerbosity::SelectionPanelFull;
+    if ui_context == UiContext::SelectionPanelLimitHeight {
+        ui_context = UiContext::SelectionPanelFull;
     }
 
     let row_height = re_ui::ReUi::table_line_height();
@@ -181,7 +181,7 @@ fn class_description_ui(
                     .sorted_by_key(|annotation| annotation.id)
                     .collect_vec();
                 ui.push_id(format!("keypoint_annotations_{}", id.0), |ui| {
-                    annotation_info_table_ui(ui, verbosity, &annotation_infos);
+                    annotation_info_table_ui(ui, ui_context, &annotation_infos);
                 });
             },
         );
@@ -197,7 +197,7 @@ fn class_description_ui(
                 ui.push_id(format!("keypoints_connections_{}", id.0), |ui| {
                     use egui_extras::Column;
 
-                    let table = table_for_verbosity(verbosity, ui)
+                    let table = table_for_ui_context(ui_context, ui)
                         .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
                         .column(Column::auto().clip(true).at_least(40.0))
                         .column(Column::auto().clip(true).at_least(40.0));
@@ -254,7 +254,7 @@ fn class_description_ui(
 
 fn annotation_info_table_ui(
     ui: &mut egui::Ui,
-    verbosity: UiVerbosity,
+    ui_context: UiContext,
     annotation_infos: &[&AnnotationInfo],
 ) {
     re_tracing::profile_function!();
@@ -265,7 +265,7 @@ fn annotation_info_table_ui(
 
     use egui_extras::Column;
 
-    let table = table_for_verbosity(verbosity, ui)
+    let table = table_for_ui_context(ui_context, ui)
         .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
         .column(Column::auto()) // id
         .column(Column::auto().clip(true).at_least(40.0)) // label

--- a/crates/re_data_ui/src/annotation_context.rs
+++ b/crates/re_data_ui/src/annotation_context.rs
@@ -35,7 +35,7 @@ impl crate::EntityDataUi for re_types::components::ClassId {
 
             let id = self.0;
             match verbosity {
-                UiVerbosity::Small => {
+                UiVerbosity::List => {
                     if !class.keypoint_connections.is_empty()
                         || !class.keypoint_annotations.is_empty()
                     {
@@ -44,7 +44,9 @@ impl crate::EntityDataUi for re_types::components::ClassId {
                         });
                     }
                 }
-                UiVerbosity::Reduced | UiVerbosity::Full | UiVerbosity::LimitHeight => {
+                UiVerbosity::Tooltip
+                | UiVerbosity::SelectionPanelFull
+                | UiVerbosity::SelectionPanelLimitHeight => {
                     ui.separator();
                     class_description_ui(ctx, ui, verbosity, class, id);
                 }
@@ -105,7 +107,7 @@ impl DataUi for AnnotationContext {
         _db: &re_entity_db::EntityDb,
     ) {
         match verbosity {
-            UiVerbosity::Small | UiVerbosity::Reduced => {
+            UiVerbosity::List | UiVerbosity::Tooltip => {
                 if self.0.len() == 1 {
                     let descr = &self.0[0].class_description;
                     ui.label(format!(
@@ -117,7 +119,7 @@ impl DataUi for AnnotationContext {
                     ui.label(format!("{} classes", self.0.len()));
                 }
             }
-            UiVerbosity::LimitHeight | UiVerbosity::Full => {
+            UiVerbosity::SelectionPanelLimitHeight | UiVerbosity::SelectionPanelFull => {
                 ui.vertical(|ui| {
                     ctx.re_ui
                         .maybe_collapsing_header(ui, true, "Classes", true, |ui| {
@@ -156,12 +158,13 @@ fn class_description_ui(
 
     re_tracing::profile_function!();
 
-    let use_collapsible = verbosity == UiVerbosity::LimitHeight || verbosity == UiVerbosity::Full;
+    let use_collapsible = verbosity == UiVerbosity::SelectionPanelLimitHeight
+        || verbosity == UiVerbosity::SelectionPanelFull;
 
     // We use collapsible header as a means for the user to limit the height, so the annotation info
     // tables can be fully unrolled.
-    if verbosity == UiVerbosity::LimitHeight {
-        verbosity = UiVerbosity::Full;
+    if verbosity == UiVerbosity::SelectionPanelLimitHeight {
+        verbosity = UiVerbosity::SelectionPanelFull;
     }
 
     let row_height = re_ui::ReUi::table_line_height();

--- a/crates/re_data_ui/src/app_id.rs
+++ b/crates/re_data_ui/src/app_id.rs
@@ -2,7 +2,7 @@ use itertools::Itertools as _;
 
 use re_entity_db::EntityDb;
 use re_log_types::ApplicationId;
-use re_viewer_context::{SystemCommandSender as _, UiVerbosity, ViewerContext};
+use re_viewer_context::{SystemCommandSender as _, UiContext, ViewerContext};
 
 use crate::item_ui::entity_db_button_ui;
 
@@ -11,9 +11,9 @@ impl crate::DataUi for ApplicationId {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
-        _db: &EntityDb,
+        _db: &re_entity_db::EntityDb,
     ) {
         egui::Grid::new("application_id")
             .num_columns(2)
@@ -26,7 +26,7 @@ impl crate::DataUi for ApplicationId {
                 ui.end_row();
             });
 
-        if verbosity == UiVerbosity::List {
+        if ui_context == UiContext::List {
             return;
         }
 
@@ -56,7 +56,7 @@ impl crate::DataUi for ApplicationId {
             ui.scope(|ui| {
                 // TODO(#6246): this test is needed because we're called in a context that may or may
                 // not have a full span defined.
-                if verbosity == UiVerbosity::Tooltip {
+                if ui_context == UiContext::Tooltip {
                     // This typically happens in tooltips, so a scope is needed
                     //TODO(ab): in the context of tooltips, ui.max_rect() doesn't provide the correct width
                     re_ui::full_span::full_span_scope(ui, ui.max_rect().x_range(), content_ui);
@@ -70,7 +70,7 @@ impl crate::DataUi for ApplicationId {
         // ---------------------------------------------------------------------
         // do not show UI code in tooltips
 
-        if verbosity != UiVerbosity::Tooltip {
+        if ui_context != UiContext::Tooltip {
             ui.add_space(8.0);
 
             // ---------------------------------------------------------------------

--- a/crates/re_data_ui/src/app_id.rs
+++ b/crates/re_data_ui/src/app_id.rs
@@ -26,7 +26,7 @@ impl crate::DataUi for ApplicationId {
                 ui.end_row();
             });
 
-        if verbosity == UiVerbosity::Small {
+        if verbosity == UiVerbosity::List {
             return;
         }
 
@@ -56,7 +56,7 @@ impl crate::DataUi for ApplicationId {
             ui.scope(|ui| {
                 // TODO(#6246): this test is needed because we're called in a context that may or may
                 // not have a full span defined.
-                if verbosity == UiVerbosity::Reduced {
+                if verbosity == UiVerbosity::Tooltip {
                     // This typically happens in tooltips, so a scope is needed
                     //TODO(ab): in the context of tooltips, ui.max_rect() doesn't provide the correct width
                     re_ui::full_span::full_span_scope(ui, ui.max_rect().x_range(), content_ui);
@@ -70,7 +70,7 @@ impl crate::DataUi for ApplicationId {
         // ---------------------------------------------------------------------
         // do not show UI code in tooltips
 
-        if verbosity != UiVerbosity::Reduced {
+        if verbosity != UiVerbosity::Tooltip {
             ui.add_space(8.0);
 
             // ---------------------------------------------------------------------

--- a/crates/re_data_ui/src/app_id.rs
+++ b/crates/re_data_ui/src/app_id.rs
@@ -2,7 +2,7 @@ use itertools::Itertools as _;
 
 use re_entity_db::EntityDb;
 use re_log_types::ApplicationId;
-use re_viewer_context::{SystemCommandSender as _, UiContext, ViewerContext};
+use re_viewer_context::{SystemCommandSender as _, UiLayout, ViewerContext};
 
 use crate::item_ui::entity_db_button_ui;
 
@@ -11,7 +11,7 @@ impl crate::DataUi for ApplicationId {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -26,7 +26,7 @@ impl crate::DataUi for ApplicationId {
                 ui.end_row();
             });
 
-        if ui_context == UiContext::List {
+        if ui_layout == UiLayout::List {
             return;
         }
 
@@ -56,7 +56,7 @@ impl crate::DataUi for ApplicationId {
             ui.scope(|ui| {
                 // TODO(#6246): this test is needed because we're called in a context that may or may
                 // not have a full span defined.
-                if ui_context == UiContext::Tooltip {
+                if ui_layout == UiLayout::Tooltip {
                     // This typically happens in tooltips, so a scope is needed
                     //TODO(ab): in the context of tooltips, ui.max_rect() doesn't provide the correct width
                     re_ui::full_span::full_span_scope(ui, ui.max_rect().x_range(), content_ui);
@@ -70,7 +70,7 @@ impl crate::DataUi for ApplicationId {
         // ---------------------------------------------------------------------
         // do not show UI code in tooltips
 
-        if ui_context != UiContext::Tooltip {
+        if ui_layout != UiLayout::Tooltip {
             ui.add_space(8.0);
 
             // ---------------------------------------------------------------------

--- a/crates/re_data_ui/src/blueprint_data.rs
+++ b/crates/re_data_ui/src/blueprint_data.rs
@@ -1,4 +1,4 @@
-use re_viewer_context::{BlueprintId, BlueprintIdRegistry, UiVerbosity, ViewerContext};
+use re_viewer_context::{BlueprintId, BlueprintIdRegistry, UiContext, ViewerContext};
 
 use crate::{item_ui::entity_path_button_to, DataUi};
 
@@ -8,7 +8,7 @@ impl<T: BlueprintIdRegistry> DataUi for BlueprintId<T> {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _verbosity: UiVerbosity,
+        _ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {

--- a/crates/re_data_ui/src/blueprint_data.rs
+++ b/crates/re_data_ui/src/blueprint_data.rs
@@ -1,4 +1,4 @@
-use re_viewer_context::{BlueprintId, BlueprintIdRegistry, UiContext, ViewerContext};
+use re_viewer_context::{BlueprintId, BlueprintIdRegistry, UiLayout, ViewerContext};
 
 use crate::{item_ui::entity_path_button_to, DataUi};
 
@@ -8,7 +8,7 @@ impl<T: BlueprintIdRegistry> DataUi for BlueprintId<T> {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_context: UiContext,
+        _ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {

--- a/crates/re_data_ui/src/blueprint_types.rs
+++ b/crates/re_data_ui/src/blueprint_types.rs
@@ -1,5 +1,5 @@
 use re_types_blueprint::blueprint::components::{IncludedSpaceView, SpaceViewMaximized};
-use re_viewer_context::{SpaceViewId, UiVerbosity, ViewerContext};
+use re_viewer_context::{SpaceViewId, UiContext, ViewerContext};
 
 use crate::DataUi;
 
@@ -11,12 +11,12 @@ impl DataUi for IncludedSpaceView {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
         let space_view: SpaceViewId = self.0.into();
-        space_view.data_ui(ctx, ui, verbosity, query, db);
+        space_view.data_ui(ctx, ui, ui_context, query, db);
     }
 }
 
@@ -26,11 +26,11 @@ impl DataUi for SpaceViewMaximized {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
         let space_view: SpaceViewId = self.0.into();
-        space_view.data_ui(ctx, ui, verbosity, query, db);
+        space_view.data_ui(ctx, ui, ui_context, query, db);
     }
 }

--- a/crates/re_data_ui/src/blueprint_types.rs
+++ b/crates/re_data_ui/src/blueprint_types.rs
@@ -1,5 +1,5 @@
 use re_types_blueprint::blueprint::components::{IncludedSpaceView, SpaceViewMaximized};
-use re_viewer_context::{SpaceViewId, UiContext, ViewerContext};
+use re_viewer_context::{SpaceViewId, UiLayout, ViewerContext};
 
 use crate::DataUi;
 
@@ -11,12 +11,12 @@ impl DataUi for IncludedSpaceView {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
         let space_view: SpaceViewId = self.0.into();
-        space_view.data_ui(ctx, ui, ui_context, query, db);
+        space_view.data_ui(ctx, ui, ui_layout, query, db);
     }
 }
 
@@ -26,11 +26,11 @@ impl DataUi for SpaceViewMaximized {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
         let space_view: SpaceViewId = self.0.into();
-        space_view.data_ui(ctx, ui, ui_context, query, db);
+        space_view.data_ui(ctx, ui, ui_layout, query, db);
     }
 }

--- a/crates/re_data_ui/src/component.rs
+++ b/crates/re_data_ui/src/component.rs
@@ -40,19 +40,23 @@ impl DataUi for EntityLatestAtResults {
         };
 
         let one_line = match verbosity {
-            UiVerbosity::Small => true,
-            UiVerbosity::Reduced | UiVerbosity::LimitHeight | UiVerbosity::Full => false,
+            UiVerbosity::List => true,
+            UiVerbosity::Tooltip
+            | UiVerbosity::SelectionPanelLimitHeight
+            | UiVerbosity::SelectionPanelFull => false,
         };
 
         // in some cases, we don't want to display all instances
         let max_row = match verbosity {
-            UiVerbosity::Small => 0,
-            UiVerbosity::Reduced => num_instances.at_most(4), // includes "…x more" if any
-            UiVerbosity::LimitHeight | UiVerbosity::Full => num_instances,
+            UiVerbosity::List => 0,
+            UiVerbosity::Tooltip => num_instances.at_most(4), // includes "…x more" if any
+            UiVerbosity::SelectionPanelLimitHeight | UiVerbosity::SelectionPanelFull => {
+                num_instances
+            }
         };
 
         // Display data time and additional diagnostic information for static components.
-        if verbosity != UiVerbosity::Small {
+        if verbosity != UiVerbosity::List {
             ui.label(format!(
                 "Data time: {}",
                 query
@@ -173,7 +177,7 @@ impl DataUi for EntityLatestAtResults {
                             ctx.component_ui_registry.ui(
                                 ctx,
                                 ui,
-                                UiVerbosity::Small,
+                                UiVerbosity::List,
                                 query,
                                 db,
                                 &self.entity_path,

--- a/crates/re_data_ui/src/component.rs
+++ b/crates/re_data_ui/src/component.rs
@@ -6,9 +6,9 @@ use re_entity_db::{external::re_query::LatestAtComponentResults, EntityPath, Ins
 use re_log_types::Instance;
 use re_types::ComponentName;
 use re_ui::SyntaxHighlighting as _;
-use re_viewer_context::{UiContext, ViewerContext};
+use re_viewer_context::{UiLayout, ViewerContext};
 
-use super::{table_for_ui_context, DataUi};
+use super::{table_for_ui_layout, DataUi};
 use crate::item_ui;
 
 /// All the values of a specific [`re_log_types::ComponentPath`].
@@ -23,7 +23,7 @@ impl DataUi for EntityLatestAtResults {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
@@ -39,22 +39,22 @@ impl DataUi for EntityLatestAtResults {
             return;
         };
 
-        let one_line = match ui_context {
-            UiContext::List => true,
-            UiContext::Tooltip
-            | UiContext::SelectionPanelLimitHeight
-            | UiContext::SelectionPanelFull => false,
+        let one_line = match ui_layout {
+            UiLayout::List => true,
+            UiLayout::Tooltip
+            | UiLayout::SelectionPanelLimitHeight
+            | UiLayout::SelectionPanelFull => false,
         };
 
         // in some cases, we don't want to display all instances
-        let max_row = match ui_context {
-            UiContext::List => 0,
-            UiContext::Tooltip => num_instances.at_most(4), // includes "…x more" if any
-            UiContext::SelectionPanelLimitHeight | UiContext::SelectionPanelFull => num_instances,
+        let max_row = match ui_layout {
+            UiLayout::List => 0,
+            UiLayout::Tooltip => num_instances.at_most(4), // includes "…x more" if any
+            UiLayout::SelectionPanelLimitHeight | UiLayout::SelectionPanelFull => num_instances,
         };
 
         // Display data time and additional diagnostic information for static components.
-        if ui_context != UiContext::List {
+        if ui_layout != UiLayout::List {
             ui.label(format!(
                 "Data time: {}",
                 query
@@ -129,7 +129,7 @@ impl DataUi for EntityLatestAtResults {
             ctx.component_ui_registry.ui(
                 ctx,
                 ui,
-                ui_context,
+                ui_layout,
                 query,
                 db,
                 &self.entity_path,
@@ -139,7 +139,7 @@ impl DataUi for EntityLatestAtResults {
         } else if one_line {
             ui.label(format!("{} values", re_format::format_uint(num_instances)));
         } else {
-            table_for_ui_context(ui_context, ui)
+            table_for_ui_layout(ui_layout, ui)
                 .resizable(false)
                 .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
                 .column(egui_extras::Column::auto())
@@ -175,7 +175,7 @@ impl DataUi for EntityLatestAtResults {
                             ctx.component_ui_registry.ui(
                                 ctx,
                                 ui,
-                                UiContext::List,
+                                UiLayout::List,
                                 query,
                                 db,
                                 &self.entity_path,

--- a/crates/re_data_ui/src/component_path.rs
+++ b/crates/re_data_ui/src/component_path.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use re_log_types::ComponentPath;
-use re_viewer_context::{UiVerbosity, ViewerContext};
+use re_viewer_context::{UiContext, ViewerContext};
 
 use super::DataUi;
 
@@ -10,7 +10,7 @@ impl DataUi for ComponentPath {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
@@ -33,7 +33,7 @@ impl DataUi for ComponentPath {
                     component_name: *component_name,
                     results: Arc::clone(results),
                 }
-                .data_ui(ctx, ui, verbosity, query, db);
+                .data_ui(ctx, ui, ui_context, query, db);
             } else if let Some(entity_tree) = ctx.recording().tree().subtree(entity_path) {
                 if entity_tree.entity.components.contains_key(component_name) {
                     ui.label("<unset>");

--- a/crates/re_data_ui/src/component_path.rs
+++ b/crates/re_data_ui/src/component_path.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use re_log_types::ComponentPath;
-use re_viewer_context::{UiContext, ViewerContext};
+use re_viewer_context::{UiLayout, ViewerContext};
 
 use super::DataUi;
 
@@ -10,7 +10,7 @@ impl DataUi for ComponentPath {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
@@ -33,7 +33,7 @@ impl DataUi for ComponentPath {
                     component_name: *component_name,
                     results: Arc::clone(results),
                 }
-                .data_ui(ctx, ui, ui_context, query, db);
+                .data_ui(ctx, ui, ui_layout, query, db);
             } else if let Some(entity_tree) = ctx.recording().tree().subtree(entity_path) {
                 if entity_tree.entity.components.contains_key(component_name) {
                     ui.label("<unset>");

--- a/crates/re_data_ui/src/component_ui_registry.rs
+++ b/crates/re_data_ui/src/component_ui_registry.rs
@@ -2,7 +2,7 @@ use re_data_store::LatestAtQuery;
 use re_entity_db::{external::re_query::LatestAtComponentResults, EntityDb};
 use re_log_types::{external::arrow2, EntityPath, Instance};
 use re_types::external::arrow2::array::Utf8Array;
-use re_viewer_context::{ComponentUiRegistry, UiContext, ViewerContext};
+use re_viewer_context::{ComponentUiRegistry, UiLayout, ViewerContext};
 
 use crate::editors::register_editors;
 
@@ -41,11 +41,11 @@ pub fn add_to_registry<C: EntityDataUi + re_types::Component>(registry: &mut Com
     registry.add(
         C::name(),
         Box::new(
-            |ctx, ui, ui_context, query, db, entity_path, component, instance| {
+            |ctx, ui, ui_layout, query, db, entity_path, component, instance| {
                 // TODO(#5607): what should happen if the promise is still pending?
                 if let Some(component) = component.instance::<C>(db.resolver(), instance.get() as _)
                 {
-                    component.entity_data_ui(ctx, ui, ui_context, entity_path, query, db);
+                    component.entity_data_ui(ctx, ui, ui_layout, entity_path, query, db);
                 } else {
                     ui.weak("(not found)");
                 }
@@ -58,7 +58,7 @@ pub fn add_to_registry<C: EntityDataUi + re_types::Component>(registry: &mut Com
 fn fallback_component_ui(
     _ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    ui_context: UiContext,
+    ui_layout: UiLayout,
     _query: &LatestAtQuery,
     db: &EntityDb,
     _entity_path: &EntityPath,
@@ -74,13 +74,13 @@ fn fallback_component_ui(
 
     // No special ui implementation - use a generic one:
     if let Some(value) = value {
-        arrow_ui(ui, ui_context, &*value);
+        arrow_ui(ui, ui_layout, &*value);
     } else {
         ui.weak("(null)");
     }
 }
 
-fn arrow_ui(ui: &mut egui::Ui, ui_context: UiContext, array: &dyn arrow2::array::Array) {
+fn arrow_ui(ui: &mut egui::Ui, ui_layout: UiLayout, array: &dyn arrow2::array::Array) {
     use re_types::SizeBytes as _;
 
     // Special-treat text.
@@ -88,14 +88,14 @@ fn arrow_ui(ui: &mut egui::Ui, ui_context: UiContext, array: &dyn arrow2::array:
     if let Some(utf8) = array.as_any().downcast_ref::<Utf8Array<i32>>() {
         if utf8.len() == 1 {
             let string = utf8.value(0);
-            text_ui(ui, ui_context, string);
+            text_ui(ui, ui_layout, string);
             return;
         }
     }
     if let Some(utf8) = array.as_any().downcast_ref::<Utf8Array<i64>>() {
         if utf8.len() == 1 {
             let string = utf8.value(0);
-            text_ui(ui, ui_context, string);
+            text_ui(ui, ui_layout, string);
             return;
         }
     }
@@ -106,7 +106,7 @@ fn arrow_ui(ui: &mut egui::Ui, ui_context: UiContext, array: &dyn arrow2::array:
         let mut string = String::new();
         let display = arrow2::array::get_display(array, "null");
         if display(&mut string, 0).is_ok() {
-            text_ui(ui, ui_context, &string);
+            text_ui(ui, ui_layout, &string);
             return;
         }
     }
@@ -119,14 +119,14 @@ fn arrow_ui(ui: &mut egui::Ui, ui_context: UiContext, array: &dyn arrow2::array:
 
     if data_type_formatted.len() < 20 {
         // e.g. "4.2 KiB of Float32"
-        text_ui(ui, ui_context, &format!("{bytes} of {data_type_formatted}"));
+        text_ui(ui, ui_layout, &format!("{bytes} of {data_type_formatted}"));
     } else {
         // Huge datatype, probably a union horror show
         ui.label(format!("{bytes} of data"));
     }
 }
 
-fn text_ui(ui: &mut egui::Ui, ui_context: UiContext, string: &str) {
+fn text_ui(ui: &mut egui::Ui, ui_layout: UiLayout, string: &str) {
     let font_id = egui::TextStyle::Monospace.resolve(ui.style());
     let color = ui.visuals().text_color();
     let wrap_width = ui.available_width();
@@ -135,20 +135,20 @@ fn text_ui(ui: &mut egui::Ui, ui_context: UiContext, string: &str) {
 
     let mut needs_scroll_area = false;
 
-    match ui_context {
-        UiContext::List => {
+    match ui_layout {
+        UiLayout::List => {
             // Elide
             layout_job.wrap.max_rows = 1;
             layout_job.wrap.break_anywhere = true;
         }
-        UiContext::Tooltip => {
+        UiLayout::Tooltip => {
             layout_job.wrap.max_rows = 3;
         }
-        UiContext::SelectionPanelLimitHeight => {
+        UiLayout::SelectionPanelLimitHeight => {
             let num_newlines = string.chars().filter(|&c| c == '\n').count();
             needs_scroll_area = 10 < num_newlines || 300 < string.len();
         }
-        UiContext::SelectionPanelFull => {
+        UiLayout::SelectionPanelFull => {
             needs_scroll_area = false;
         }
     }

--- a/crates/re_data_ui/src/component_ui_registry.rs
+++ b/crates/re_data_ui/src/component_ui_registry.rs
@@ -136,19 +136,19 @@ fn text_ui(ui: &mut egui::Ui, verbosity: UiVerbosity, string: &str) {
     let mut needs_scroll_area = false;
 
     match verbosity {
-        UiVerbosity::Small => {
+        UiVerbosity::List => {
             // Elide
             layout_job.wrap.max_rows = 1;
             layout_job.wrap.break_anywhere = true;
         }
-        UiVerbosity::Reduced => {
+        UiVerbosity::Tooltip => {
             layout_job.wrap.max_rows = 3;
         }
-        UiVerbosity::LimitHeight => {
+        UiVerbosity::SelectionPanelLimitHeight => {
             let num_newlines = string.chars().filter(|&c| c == '\n').count();
             needs_scroll_area = 10 < num_newlines || 300 < string.len();
         }
-        UiVerbosity::Full => {
+        UiVerbosity::SelectionPanelFull => {
             needs_scroll_area = false;
         }
     }

--- a/crates/re_data_ui/src/component_ui_registry.rs
+++ b/crates/re_data_ui/src/component_ui_registry.rs
@@ -2,7 +2,7 @@ use re_data_store::LatestAtQuery;
 use re_entity_db::{external::re_query::LatestAtComponentResults, EntityDb};
 use re_log_types::{external::arrow2, EntityPath, Instance};
 use re_types::external::arrow2::array::Utf8Array;
-use re_viewer_context::{ComponentUiRegistry, UiVerbosity, ViewerContext};
+use re_viewer_context::{ComponentUiRegistry, UiContext, ViewerContext};
 
 use crate::editors::register_editors;
 
@@ -41,11 +41,11 @@ pub fn add_to_registry<C: EntityDataUi + re_types::Component>(registry: &mut Com
     registry.add(
         C::name(),
         Box::new(
-            |ctx, ui, verbosity, query, db, entity_path, component, instance| {
+            |ctx, ui, ui_context, query, db, entity_path, component, instance| {
                 // TODO(#5607): what should happen if the promise is still pending?
                 if let Some(component) = component.instance::<C>(db.resolver(), instance.get() as _)
                 {
-                    component.entity_data_ui(ctx, ui, verbosity, entity_path, query, db);
+                    component.entity_data_ui(ctx, ui, ui_context, entity_path, query, db);
                 } else {
                     ui.weak("(not found)");
                 }
@@ -58,7 +58,7 @@ pub fn add_to_registry<C: EntityDataUi + re_types::Component>(registry: &mut Com
 fn fallback_component_ui(
     _ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    verbosity: UiVerbosity,
+    ui_context: UiContext,
     _query: &LatestAtQuery,
     db: &EntityDb,
     _entity_path: &EntityPath,
@@ -74,13 +74,13 @@ fn fallback_component_ui(
 
     // No special ui implementation - use a generic one:
     if let Some(value) = value {
-        arrow_ui(ui, verbosity, &*value);
+        arrow_ui(ui, ui_context, &*value);
     } else {
         ui.weak("(null)");
     }
 }
 
-fn arrow_ui(ui: &mut egui::Ui, verbosity: UiVerbosity, array: &dyn arrow2::array::Array) {
+fn arrow_ui(ui: &mut egui::Ui, ui_context: UiContext, array: &dyn arrow2::array::Array) {
     use re_types::SizeBytes as _;
 
     // Special-treat text.
@@ -88,14 +88,14 @@ fn arrow_ui(ui: &mut egui::Ui, verbosity: UiVerbosity, array: &dyn arrow2::array
     if let Some(utf8) = array.as_any().downcast_ref::<Utf8Array<i32>>() {
         if utf8.len() == 1 {
             let string = utf8.value(0);
-            text_ui(ui, verbosity, string);
+            text_ui(ui, ui_context, string);
             return;
         }
     }
     if let Some(utf8) = array.as_any().downcast_ref::<Utf8Array<i64>>() {
         if utf8.len() == 1 {
             let string = utf8.value(0);
-            text_ui(ui, verbosity, string);
+            text_ui(ui, ui_context, string);
             return;
         }
     }
@@ -106,7 +106,7 @@ fn arrow_ui(ui: &mut egui::Ui, verbosity: UiVerbosity, array: &dyn arrow2::array
         let mut string = String::new();
         let display = arrow2::array::get_display(array, "null");
         if display(&mut string, 0).is_ok() {
-            text_ui(ui, verbosity, &string);
+            text_ui(ui, ui_context, &string);
             return;
         }
     }
@@ -119,14 +119,14 @@ fn arrow_ui(ui: &mut egui::Ui, verbosity: UiVerbosity, array: &dyn arrow2::array
 
     if data_type_formatted.len() < 20 {
         // e.g. "4.2 KiB of Float32"
-        text_ui(ui, verbosity, &format!("{bytes} of {data_type_formatted}"));
+        text_ui(ui, ui_context, &format!("{bytes} of {data_type_formatted}"));
     } else {
         // Huge datatype, probably a union horror show
         ui.label(format!("{bytes} of data"));
     }
 }
 
-fn text_ui(ui: &mut egui::Ui, verbosity: UiVerbosity, string: &str) {
+fn text_ui(ui: &mut egui::Ui, ui_context: UiContext, string: &str) {
     let font_id = egui::TextStyle::Monospace.resolve(ui.style());
     let color = ui.visuals().text_color();
     let wrap_width = ui.available_width();
@@ -135,20 +135,20 @@ fn text_ui(ui: &mut egui::Ui, verbosity: UiVerbosity, string: &str) {
 
     let mut needs_scroll_area = false;
 
-    match verbosity {
-        UiVerbosity::List => {
+    match ui_context {
+        UiContext::List => {
             // Elide
             layout_job.wrap.max_rows = 1;
             layout_job.wrap.break_anywhere = true;
         }
-        UiVerbosity::Tooltip => {
+        UiContext::Tooltip => {
             layout_job.wrap.max_rows = 3;
         }
-        UiVerbosity::SelectionPanelLimitHeight => {
+        UiContext::SelectionPanelLimitHeight => {
             let num_newlines = string.chars().filter(|&c| c == '\n').count();
             needs_scroll_area = 10 < num_newlines || 300 < string.len();
         }
-        UiVerbosity::SelectionPanelFull => {
+        UiContext::SelectionPanelFull => {
             needs_scroll_area = false;
         }
     }

--- a/crates/re_data_ui/src/data.rs
+++ b/crates/re_data_ui/src/data.rs
@@ -61,11 +61,13 @@ impl DataUi for ViewCoordinates {
         _db: &re_entity_db::EntityDb,
     ) {
         match verbosity {
-            UiVerbosity::Small => {
+            UiVerbosity::List => {
                 ui.label(self.describe_short())
                     .on_hover_text(self.describe());
             }
-            UiVerbosity::Full | UiVerbosity::LimitHeight | UiVerbosity::Reduced => {
+            UiVerbosity::SelectionPanelFull
+            | UiVerbosity::SelectionPanelLimitHeight
+            | UiVerbosity::Tooltip => {
                 ui.label(self.describe());
             }
         }
@@ -188,10 +190,10 @@ impl DataUi for LineStrip2D {
         _db: &re_entity_db::EntityDb,
     ) {
         match verbosity {
-            UiVerbosity::Small | UiVerbosity::Reduced => {
+            UiVerbosity::List | UiVerbosity::Tooltip => {
                 ui.label(format!("{} positions", self.0.len()));
             }
-            UiVerbosity::LimitHeight | UiVerbosity::Full => {
+            UiVerbosity::SelectionPanelLimitHeight | UiVerbosity::SelectionPanelFull => {
                 use egui_extras::Column;
                 table_for_verbosity(verbosity, ui)
                     .resizable(true)
@@ -235,10 +237,10 @@ impl DataUi for LineStrip3D {
         _db: &re_entity_db::EntityDb,
     ) {
         match verbosity {
-            UiVerbosity::Small | UiVerbosity::Reduced => {
+            UiVerbosity::List | UiVerbosity::Tooltip => {
                 ui.label(format!("{} positions", self.0.len()));
             }
-            UiVerbosity::Full | UiVerbosity::LimitHeight => {
+            UiVerbosity::SelectionPanelFull | UiVerbosity::SelectionPanelLimitHeight => {
                 use egui_extras::Column;
                 table_for_verbosity(verbosity, ui)
                     .resizable(true)

--- a/crates/re_data_ui/src/data.rs
+++ b/crates/re_data_ui/src/data.rs
@@ -2,9 +2,9 @@ use egui::Vec2;
 
 use re_format::format_f32;
 use re_types::components::{Color, LineStrip2D, LineStrip3D, ViewCoordinates};
-use re_viewer_context::{UiVerbosity, ViewerContext};
+use re_viewer_context::{UiContext, ViewerContext};
 
-use super::{table_for_verbosity, DataUi};
+use super::{table_for_ui_context, DataUi};
 
 /// Default number of ui points to show a number.
 const DEFAULT_NUMBER_WIDTH: f32 = 52.0;
@@ -14,7 +14,7 @@ impl DataUi for [u8; 4] {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _verbosity: UiVerbosity,
+        _ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -35,7 +35,7 @@ impl DataUi for Color {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _verbosity: UiVerbosity,
+        _ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -56,18 +56,18 @@ impl DataUi for ViewCoordinates {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        match verbosity {
-            UiVerbosity::List => {
+        match ui_context {
+            UiContext::List => {
                 ui.label(self.describe_short())
                     .on_hover_text(self.describe());
             }
-            UiVerbosity::SelectionPanelFull
-            | UiVerbosity::SelectionPanelLimitHeight
-            | UiVerbosity::Tooltip => {
+            UiContext::SelectionPanelFull
+            | UiContext::SelectionPanelLimitHeight
+            | UiContext::Tooltip => {
                 ui.label(self.describe());
             }
         }
@@ -79,7 +79,7 @@ impl DataUi for re_types::datatypes::Mat3x3 {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _verbosity: UiVerbosity,
+        _ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -107,7 +107,7 @@ impl DataUi for re_types::datatypes::Vec2D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _verbosity: UiVerbosity,
+        _ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -120,7 +120,7 @@ impl DataUi for re_types::datatypes::Vec3D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _verbosity: UiVerbosity,
+        _ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -133,7 +133,7 @@ impl DataUi for re_types::datatypes::Vec4D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _verbosity: UiVerbosity,
+        _ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -146,7 +146,7 @@ impl DataUi for re_types::datatypes::UVec2D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _verbosity: UiVerbosity,
+        _ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -159,7 +159,7 @@ impl DataUi for re_types::datatypes::UVec3D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _verbosity: UiVerbosity,
+        _ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -172,7 +172,7 @@ impl DataUi for re_types::datatypes::UVec4D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _verbosity: UiVerbosity,
+        _ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -185,17 +185,17 @@ impl DataUi for LineStrip2D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        match verbosity {
-            UiVerbosity::List | UiVerbosity::Tooltip => {
+        match ui_context {
+            UiContext::List | UiContext::Tooltip => {
                 ui.label(format!("{} positions", self.0.len()));
             }
-            UiVerbosity::SelectionPanelLimitHeight | UiVerbosity::SelectionPanelFull => {
+            UiContext::SelectionPanelLimitHeight | UiContext::SelectionPanelFull => {
                 use egui_extras::Column;
-                table_for_verbosity(verbosity, ui)
+                table_for_ui_context(ui_context, ui)
                     .resizable(true)
                     .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
                     .columns(Column::initial(DEFAULT_NUMBER_WIDTH).clip(true), 2)
@@ -232,17 +232,17 @@ impl DataUi for LineStrip3D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        match verbosity {
-            UiVerbosity::List | UiVerbosity::Tooltip => {
+        match ui_context {
+            UiContext::List | UiContext::Tooltip => {
                 ui.label(format!("{} positions", self.0.len()));
             }
-            UiVerbosity::SelectionPanelFull | UiVerbosity::SelectionPanelLimitHeight => {
+            UiContext::SelectionPanelFull | UiContext::SelectionPanelLimitHeight => {
                 use egui_extras::Column;
-                table_for_verbosity(verbosity, ui)
+                table_for_ui_context(ui_context, ui)
                     .resizable(true)
                     .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
                     .columns(Column::initial(DEFAULT_NUMBER_WIDTH).clip(true), 3)

--- a/crates/re_data_ui/src/data.rs
+++ b/crates/re_data_ui/src/data.rs
@@ -2,9 +2,9 @@ use egui::Vec2;
 
 use re_format::format_f32;
 use re_types::components::{Color, LineStrip2D, LineStrip3D, ViewCoordinates};
-use re_viewer_context::{UiContext, ViewerContext};
+use re_viewer_context::{UiLayout, ViewerContext};
 
-use super::{table_for_ui_context, DataUi};
+use super::{table_for_ui_layout, DataUi};
 
 /// Default number of ui points to show a number.
 const DEFAULT_NUMBER_WIDTH: f32 = 52.0;
@@ -14,7 +14,7 @@ impl DataUi for [u8; 4] {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_context: UiContext,
+        _ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -35,7 +35,7 @@ impl DataUi for Color {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_context: UiContext,
+        _ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -56,18 +56,18 @@ impl DataUi for ViewCoordinates {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        match ui_context {
-            UiContext::List => {
+        match ui_layout {
+            UiLayout::List => {
                 ui.label(self.describe_short())
                     .on_hover_text(self.describe());
             }
-            UiContext::SelectionPanelFull
-            | UiContext::SelectionPanelLimitHeight
-            | UiContext::Tooltip => {
+            UiLayout::SelectionPanelFull
+            | UiLayout::SelectionPanelLimitHeight
+            | UiLayout::Tooltip => {
                 ui.label(self.describe());
             }
         }
@@ -79,7 +79,7 @@ impl DataUi for re_types::datatypes::Mat3x3 {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_context: UiContext,
+        _ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -107,7 +107,7 @@ impl DataUi for re_types::datatypes::Vec2D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_context: UiContext,
+        _ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -120,7 +120,7 @@ impl DataUi for re_types::datatypes::Vec3D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_context: UiContext,
+        _ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -133,7 +133,7 @@ impl DataUi for re_types::datatypes::Vec4D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_context: UiContext,
+        _ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -146,7 +146,7 @@ impl DataUi for re_types::datatypes::UVec2D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_context: UiContext,
+        _ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -159,7 +159,7 @@ impl DataUi for re_types::datatypes::UVec3D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_context: UiContext,
+        _ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -172,7 +172,7 @@ impl DataUi for re_types::datatypes::UVec4D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_context: UiContext,
+        _ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -185,17 +185,17 @@ impl DataUi for LineStrip2D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        match ui_context {
-            UiContext::List | UiContext::Tooltip => {
+        match ui_layout {
+            UiLayout::List | UiLayout::Tooltip => {
                 ui.label(format!("{} positions", self.0.len()));
             }
-            UiContext::SelectionPanelLimitHeight | UiContext::SelectionPanelFull => {
+            UiLayout::SelectionPanelLimitHeight | UiLayout::SelectionPanelFull => {
                 use egui_extras::Column;
-                table_for_ui_context(ui_context, ui)
+                table_for_ui_layout(ui_layout, ui)
                     .resizable(true)
                     .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
                     .columns(Column::initial(DEFAULT_NUMBER_WIDTH).clip(true), 2)
@@ -232,17 +232,17 @@ impl DataUi for LineStrip3D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        match ui_context {
-            UiContext::List | UiContext::Tooltip => {
+        match ui_layout {
+            UiLayout::List | UiLayout::Tooltip => {
                 ui.label(format!("{} positions", self.0.len()));
             }
-            UiContext::SelectionPanelFull | UiContext::SelectionPanelLimitHeight => {
+            UiLayout::SelectionPanelFull | UiLayout::SelectionPanelLimitHeight => {
                 use egui_extras::Column;
-                table_for_ui_context(ui_context, ui)
+                table_for_ui_layout(ui_layout, ui)
                     .resizable(true)
                     .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
                     .columns(Column::initial(DEFAULT_NUMBER_WIDTH).clip(true), 3)

--- a/crates/re_data_ui/src/data_source.rs
+++ b/crates/re_data_ui/src/data_source.rs
@@ -1,5 +1,5 @@
 use re_log_types::StoreKind;
-use re_viewer_context::{UiContext, ViewerContext};
+use re_viewer_context::{UiLayout, ViewerContext};
 
 use crate::item_ui::entity_db_button_ui;
 
@@ -8,13 +8,13 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
         ui.label(self.to_string());
 
-        if ui_context == UiContext::List {
+        if ui_layout == UiLayout::List {
             return;
         }
 
@@ -73,7 +73,7 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
 
             // TODO(#6246): this test is needed because we're called in a context that may or may
             // not have a full span defined.
-            if ui_context == UiContext::Tooltip {
+            if ui_layout == UiLayout::Tooltip {
                 // This typically happens in tooltips, so a scope is needed
                 //TODO(ab): in the context of tooltips, ui.max_rect() doesn't provide the correct width
                 re_ui::full_span::full_span_scope(ui, ui.max_rect().x_range(), content_ui);

--- a/crates/re_data_ui/src/data_source.rs
+++ b/crates/re_data_ui/src/data_source.rs
@@ -1,5 +1,5 @@
 use re_log_types::StoreKind;
-use re_viewer_context::{UiVerbosity, ViewerContext};
+use re_viewer_context::{UiContext, ViewerContext};
 
 use crate::item_ui::entity_db_button_ui;
 
@@ -8,13 +8,13 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
         ui.label(self.to_string());
 
-        if verbosity == UiVerbosity::List {
+        if ui_context == UiContext::List {
             return;
         }
 
@@ -73,7 +73,7 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
 
             // TODO(#6246): this test is needed because we're called in a context that may or may
             // not have a full span defined.
-            if verbosity == UiVerbosity::Tooltip {
+            if ui_context == UiContext::Tooltip {
                 // This typically happens in tooltips, so a scope is needed
                 //TODO(ab): in the context of tooltips, ui.max_rect() doesn't provide the correct width
                 re_ui::full_span::full_span_scope(ui, ui.max_rect().x_range(), content_ui);

--- a/crates/re_data_ui/src/data_source.rs
+++ b/crates/re_data_ui/src/data_source.rs
@@ -14,7 +14,7 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
     ) {
         ui.label(self.to_string());
 
-        if verbosity == UiVerbosity::Small {
+        if verbosity == UiVerbosity::List {
             return;
         }
 
@@ -73,7 +73,7 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
 
             // TODO(#6246): this test is needed because we're called in a context that may or may
             // not have a full span defined.
-            if verbosity == UiVerbosity::Reduced {
+            if verbosity == UiVerbosity::Tooltip {
                 // This typically happens in tooltips, so a scope is needed
                 //TODO(ab): in the context of tooltips, ui.max_rect() doesn't provide the correct width
                 re_ui::full_span::full_span_scope(ui, ui.max_rect().x_range(), content_ui);

--- a/crates/re_data_ui/src/editors.rs
+++ b/crates/re_data_ui/src/editors.rs
@@ -10,7 +10,7 @@ use re_types::{
     },
     Component, Loggable,
 };
-use re_viewer_context::{UiContext, ViewerContext};
+use re_viewer_context::{UiLayout, ViewerContext};
 
 // ----
 
@@ -18,7 +18,7 @@ use re_viewer_context::{UiContext, ViewerContext};
 fn edit_color_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _ui_context: UiContext,
+    _ui_layout: UiLayout,
     query: &LatestAtQuery,
     db: &EntityDb,
     entity_path: &EntityPath,
@@ -61,7 +61,7 @@ fn default_color(
 fn edit_text_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _ui_context: UiContext,
+    _ui_layout: UiLayout,
     query: &LatestAtQuery,
     db: &EntityDb,
     entity_path: &EntityPath,
@@ -101,7 +101,7 @@ fn default_text(
 fn edit_name_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _ui_context: UiContext,
+    _ui_layout: UiLayout,
     query: &LatestAtQuery,
     db: &EntityDb,
     entity_path: &EntityPath,
@@ -142,7 +142,7 @@ fn default_name(
 fn edit_scatter_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _ui_context: UiContext,
+    _ui_layout: UiLayout,
     query: &LatestAtQuery,
     db: &EntityDb,
     entity_path: &EntityPath,
@@ -191,7 +191,7 @@ fn default_scatter(
 fn edit_radius_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _ui_context: UiContext,
+    _ui_layout: UiLayout,
     query: &LatestAtQuery,
     db: &EntityDb,
     entity_path: &EntityPath,
@@ -238,7 +238,7 @@ fn default_radius(
 fn edit_marker_shape_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _ui_context: UiContext,
+    _ui_layout: UiLayout,
     query: &LatestAtQuery,
     db: &EntityDb,
     entity_path: &EntityPath,
@@ -343,7 +343,7 @@ fn paint_marker(
 fn edit_stroke_width_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _ui_context: UiContext,
+    _ui_layout: UiLayout,
     query: &LatestAtQuery,
     db: &EntityDb,
     entity_path: &EntityPath,
@@ -390,7 +390,7 @@ fn default_stroke_width(
 fn edit_marker_size_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _ui_context: UiContext,
+    _ui_layout: UiLayout,
     query: &LatestAtQuery,
     db: &EntityDb,
     entity_path: &EntityPath,
@@ -439,7 +439,7 @@ fn register_editor<'a, C>(
     edit: fn(
         &ViewerContext<'_>,
         &mut egui::Ui,
-        UiContext,
+        UiLayout,
         &LatestAtQuery,
         &EntityDb,
         &EntityPath,

--- a/crates/re_data_ui/src/editors.rs
+++ b/crates/re_data_ui/src/editors.rs
@@ -10,7 +10,7 @@ use re_types::{
     },
     Component, Loggable,
 };
-use re_viewer_context::{UiVerbosity, ViewerContext};
+use re_viewer_context::{UiContext, ViewerContext};
 
 // ----
 
@@ -18,7 +18,7 @@ use re_viewer_context::{UiVerbosity, ViewerContext};
 fn edit_color_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _verbosity: UiVerbosity,
+    _ui_context: UiContext,
     query: &LatestAtQuery,
     db: &EntityDb,
     entity_path: &EntityPath,
@@ -61,7 +61,7 @@ fn default_color(
 fn edit_text_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _verbosity: UiVerbosity,
+    _ui_context: UiContext,
     query: &LatestAtQuery,
     db: &EntityDb,
     entity_path: &EntityPath,
@@ -101,7 +101,7 @@ fn default_text(
 fn edit_name_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _verbosity: UiVerbosity,
+    _ui_context: UiContext,
     query: &LatestAtQuery,
     db: &EntityDb,
     entity_path: &EntityPath,
@@ -142,7 +142,7 @@ fn default_name(
 fn edit_scatter_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _verbosity: UiVerbosity,
+    _ui_context: UiContext,
     query: &LatestAtQuery,
     db: &EntityDb,
     entity_path: &EntityPath,
@@ -191,7 +191,7 @@ fn default_scatter(
 fn edit_radius_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _verbosity: UiVerbosity,
+    _ui_context: UiContext,
     query: &LatestAtQuery,
     db: &EntityDb,
     entity_path: &EntityPath,
@@ -238,7 +238,7 @@ fn default_radius(
 fn edit_marker_shape_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _verbosity: UiVerbosity,
+    _ui_context: UiContext,
     query: &LatestAtQuery,
     db: &EntityDb,
     entity_path: &EntityPath,
@@ -343,7 +343,7 @@ fn paint_marker(
 fn edit_stroke_width_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _verbosity: UiVerbosity,
+    _ui_context: UiContext,
     query: &LatestAtQuery,
     db: &EntityDb,
     entity_path: &EntityPath,
@@ -390,7 +390,7 @@ fn default_stroke_width(
 fn edit_marker_size_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _verbosity: UiVerbosity,
+    _ui_context: UiContext,
     query: &LatestAtQuery,
     db: &EntityDb,
     entity_path: &EntityPath,
@@ -439,7 +439,7 @@ fn register_editor<'a, C>(
     edit: fn(
         &ViewerContext<'_>,
         &mut egui::Ui,
-        UiVerbosity,
+        UiContext,
         &LatestAtQuery,
         &EntityDb,
         &EntityPath,

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -1,7 +1,7 @@
 use re_entity_db::EntityDb;
 use re_log_types::StoreKind;
 use re_types::SizeBytes;
-use re_viewer_context::{UiVerbosity, ViewerContext};
+use re_viewer_context::{UiContext, ViewerContext};
 
 use crate::item_ui::{app_id_button_ui, data_source_button_ui};
 
@@ -10,13 +10,13 @@ impl crate::DataUi for EntityDb {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
         let re_ui = &ctx.re_ui;
 
-        if verbosity == UiVerbosity::List {
+        if ui_context == UiContext::List {
             // TODO(emilk): standardize this formatting with that in `entity_db_button_ui`
             let mut string = self.store_id().to_string();
             if let Some(data_source) = &self.data_source {

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -16,7 +16,7 @@ impl crate::DataUi for EntityDb {
     ) {
         let re_ui = &ctx.re_ui;
 
-        if verbosity == UiVerbosity::Small {
+        if verbosity == UiVerbosity::List {
             // TODO(emilk): standardize this formatting with that in `entity_db_button_ui`
             let mut string = self.store_id().to_string();
             if let Some(data_source) = &self.data_source {

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -1,7 +1,7 @@
 use re_entity_db::EntityDb;
 use re_log_types::StoreKind;
 use re_types::SizeBytes;
-use re_viewer_context::{UiContext, ViewerContext};
+use re_viewer_context::{UiLayout, ViewerContext};
 
 use crate::item_ui::{app_id_button_ui, data_source_button_ui};
 
@@ -10,13 +10,13 @@ impl crate::DataUi for EntityDb {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
         let re_ui = &ctx.re_ui;
 
-        if ui_context == UiContext::List {
+        if ui_layout == UiLayout::List {
             // TODO(emilk): standardize this formatting with that in `entity_db_button_ui`
             let mut string = self.store_id().to_string();
             if let Some(data_source) = &self.data_source {

--- a/crates/re_data_ui/src/entity_path.rs
+++ b/crates/re_data_ui/src/entity_path.rs
@@ -1,5 +1,5 @@
 use re_entity_db::InstancePath;
-use re_viewer_context::{UiVerbosity, ViewerContext};
+use re_viewer_context::{UiContext, ViewerContext};
 
 use super::DataUi;
 
@@ -8,10 +8,10 @@ impl DataUi for re_entity_db::EntityPath {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
-        InstancePath::entity_all(self.clone()).data_ui(ctx, ui, verbosity, query, db);
+        InstancePath::entity_all(self.clone()).data_ui(ctx, ui, ui_context, query, db);
     }
 }

--- a/crates/re_data_ui/src/entity_path.rs
+++ b/crates/re_data_ui/src/entity_path.rs
@@ -1,5 +1,5 @@
 use re_entity_db::InstancePath;
-use re_viewer_context::{UiContext, ViewerContext};
+use re_viewer_context::{UiLayout, ViewerContext};
 
 use super::DataUi;
 
@@ -8,10 +8,10 @@ impl DataUi for re_entity_db::EntityPath {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
-        InstancePath::entity_all(self.clone()).data_ui(ctx, ui, ui_context, query, db);
+        InstancePath::entity_all(self.clone()).data_ui(ctx, ui, ui_layout, query, db);
     }
 }

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -113,7 +113,7 @@ pub fn tensor_ui(
     .ok();
 
     match verbosity {
-        UiVerbosity::Small => {
+        UiVerbosity::List => {
             ui.horizontal(|ui| {
                 if let Some(texture) = &texture_result {
                     // We want all preview images to take up the same amount of space,
@@ -172,7 +172,9 @@ pub fn tensor_ui(
             });
         }
 
-        UiVerbosity::Full | UiVerbosity::LimitHeight | UiVerbosity::Reduced => {
+        UiVerbosity::SelectionPanelFull
+        | UiVerbosity::SelectionPanelLimitHeight
+        | UiVerbosity::Tooltip => {
             ui.vertical(|ui| {
                 ui.set_min_width(100.0);
                 tensor_summary_ui(

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -8,7 +8,7 @@ use re_types::datatypes::{TensorBuffer, TensorData, TensorDimension};
 use re_types::tensor_data::{DecodedTensor, TensorDataMeaning, TensorElement};
 use re_ui::ReUi;
 use re_viewer_context::{
-    gpu_bridge, Annotations, TensorDecodeCache, TensorStats, TensorStatsCache, UiContext,
+    gpu_bridge, Annotations, TensorDecodeCache, TensorStats, TensorStatsCache, UiLayout,
     ViewerContext,
 };
 
@@ -31,7 +31,7 @@ impl EntityDataUi for re_types::components::TensorData {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         entity_path: &EntityPath,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
@@ -55,7 +55,7 @@ impl EntityDataUi for re_types::components::TensorData {
                     query,
                     db,
                     ui,
-                    ui_context,
+                    ui_layout,
                     entity_path,
                     &annotations,
                     tensor_data_row_id,
@@ -76,7 +76,7 @@ pub fn tensor_ui(
     query: &re_data_store::LatestAtQuery,
     db: &re_entity_db::EntityDb,
     ui: &mut egui::Ui,
-    ui_context: UiContext,
+    ui_layout: UiLayout,
     entity_path: &re_entity_db::EntityPath,
     annotations: &Annotations,
     tensor_data_row_id: RowId,
@@ -112,8 +112,8 @@ pub fn tensor_ui(
     )
     .ok();
 
-    match ui_context {
-        UiContext::List => {
+    match ui_layout {
+        UiLayout::List => {
             ui.horizontal(|ui| {
                 if let Some(texture) = &texture_result {
                     // We want all preview images to take up the same amount of space,
@@ -172,9 +172,7 @@ pub fn tensor_ui(
             });
         }
 
-        UiContext::SelectionPanelFull
-        | UiContext::SelectionPanelLimitHeight
-        | UiContext::Tooltip => {
+        UiLayout::SelectionPanelFull | UiLayout::SelectionPanelLimitHeight | UiLayout::Tooltip => {
             ui.vertical(|ui| {
                 ui.set_min_width(100.0);
                 tensor_summary_ui(

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -1,14 +1,14 @@
 use egui::{Color32, Vec2};
 use itertools::Itertools as _;
 
-use re_log_types::RowId;
+use re_log_types::{EntityPath, RowId};
 use re_renderer::renderer::ColormappedTexture;
 use re_types::components::{ClassId, DepthMeter};
 use re_types::datatypes::{TensorBuffer, TensorData, TensorDimension};
 use re_types::tensor_data::{DecodedTensor, TensorDataMeaning, TensorElement};
 use re_ui::ReUi;
 use re_viewer_context::{
-    gpu_bridge, Annotations, TensorDecodeCache, TensorStats, TensorStatsCache, UiVerbosity,
+    gpu_bridge, Annotations, TensorDecodeCache, TensorStats, TensorStatsCache, UiContext,
     ViewerContext,
 };
 
@@ -31,8 +31,8 @@ impl EntityDataUi for re_types::components::TensorData {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
-        entity_path: &re_log_types::EntityPath,
+        ui_context: UiContext,
+        entity_path: &EntityPath,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
@@ -55,7 +55,7 @@ impl EntityDataUi for re_types::components::TensorData {
                     query,
                     db,
                     ui,
-                    verbosity,
+                    ui_context,
                     entity_path,
                     &annotations,
                     tensor_data_row_id,
@@ -76,7 +76,7 @@ pub fn tensor_ui(
     query: &re_data_store::LatestAtQuery,
     db: &re_entity_db::EntityDb,
     ui: &mut egui::Ui,
-    verbosity: UiVerbosity,
+    ui_context: UiContext,
     entity_path: &re_entity_db::EntityPath,
     annotations: &Annotations,
     tensor_data_row_id: RowId,
@@ -112,8 +112,8 @@ pub fn tensor_ui(
     )
     .ok();
 
-    match verbosity {
-        UiVerbosity::List => {
+    match ui_context {
+        UiContext::List => {
             ui.horizontal(|ui| {
                 if let Some(texture) = &texture_result {
                     // We want all preview images to take up the same amount of space,
@@ -172,9 +172,9 @@ pub fn tensor_ui(
             });
         }
 
-        UiVerbosity::SelectionPanelFull
-        | UiVerbosity::SelectionPanelLimitHeight
-        | UiVerbosity::Tooltip => {
+        UiContext::SelectionPanelFull
+        | UiContext::SelectionPanelLimitHeight
+        | UiContext::Tooltip => {
             ui.vertical(|ui| {
                 ui.set_min_width(100.0);
                 tensor_summary_ui(

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use re_entity_db::InstancePath;
 use re_log_types::ComponentPath;
-use re_viewer_context::{UiContext, ViewerContext};
+use re_viewer_context::{UiLayout, ViewerContext};
 
 use super::DataUi;
 use crate::item_ui;
@@ -12,7 +12,7 @@ impl DataUi for InstancePath {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
@@ -46,13 +46,13 @@ impl DataUi for InstancePath {
         let normal_components = components.split_off(split);
         let indicator_components = components;
 
-        let show_indicator_comps = match ui_context {
-            UiContext::List | UiContext::Tooltip => {
+        let show_indicator_comps = match ui_layout {
+            UiLayout::List | UiLayout::Tooltip => {
                 // Skip indicator components in hover ui (unless there are no other
                 // types of components).
                 !normal_components.is_empty()
             }
-            UiContext::SelectionPanelLimitHeight | UiContext::SelectionPanelFull => true,
+            UiLayout::SelectionPanelLimitHeight | UiLayout::SelectionPanelFull => true,
         };
 
         // First show indicator components, outside the grid:
@@ -96,12 +96,12 @@ impl DataUi for InstancePath {
                             component_name,
                             results: Arc::clone(results),
                         }
-                        .data_ui(ctx, ui, UiContext::List, query, db);
+                        .data_ui(ctx, ui, UiLayout::List, query, db);
                     } else {
                         ctx.component_ui_registry.ui(
                             ctx,
                             ui,
-                            UiContext::List,
+                            UiLayout::List,
                             query,
                             db,
                             entity_path,

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use re_entity_db::InstancePath;
 use re_log_types::ComponentPath;
-use re_viewer_context::{UiVerbosity, ViewerContext};
+use re_viewer_context::{UiContext, ViewerContext};
 
 use super::DataUi;
 use crate::item_ui;
@@ -12,7 +12,7 @@ impl DataUi for InstancePath {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
@@ -46,13 +46,13 @@ impl DataUi for InstancePath {
         let normal_components = components.split_off(split);
         let indicator_components = components;
 
-        let show_indicator_comps = match verbosity {
-            UiVerbosity::List | UiVerbosity::Tooltip => {
+        let show_indicator_comps = match ui_context {
+            UiContext::List | UiContext::Tooltip => {
                 // Skip indicator components in hover ui (unless there are no other
                 // types of components).
                 !normal_components.is_empty()
             }
-            UiVerbosity::SelectionPanelLimitHeight | UiVerbosity::SelectionPanelFull => true,
+            UiContext::SelectionPanelLimitHeight | UiContext::SelectionPanelFull => true,
         };
 
         // First show indicator components, outside the grid:
@@ -96,12 +96,12 @@ impl DataUi for InstancePath {
                             component_name,
                             results: Arc::clone(results),
                         }
-                        .data_ui(ctx, ui, UiVerbosity::List, query, db);
+                        .data_ui(ctx, ui, UiContext::List, query, db);
                     } else {
                         ctx.component_ui_registry.ui(
                             ctx,
                             ui,
-                            UiVerbosity::List,
+                            UiContext::List,
                             query,
                             db,
                             entity_path,

--- a/crates/re_data_ui/src/instance_path.rs
+++ b/crates/re_data_ui/src/instance_path.rs
@@ -47,12 +47,12 @@ impl DataUi for InstancePath {
         let indicator_components = components;
 
         let show_indicator_comps = match verbosity {
-            UiVerbosity::Small | UiVerbosity::Reduced => {
+            UiVerbosity::List | UiVerbosity::Tooltip => {
                 // Skip indicator components in hover ui (unless there are no other
                 // types of components).
                 !normal_components.is_empty()
             }
-            UiVerbosity::LimitHeight | UiVerbosity::Full => true,
+            UiVerbosity::SelectionPanelLimitHeight | UiVerbosity::SelectionPanelFull => true,
         };
 
         // First show indicator components, outside the grid:
@@ -96,12 +96,12 @@ impl DataUi for InstancePath {
                             component_name,
                             results: Arc::clone(results),
                         }
-                        .data_ui(ctx, ui, UiVerbosity::Small, query, db);
+                        .data_ui(ctx, ui, UiVerbosity::List, query, db);
                     } else {
                         ctx.component_ui_registry.ui(
                             ctx,
                             ui,
-                            UiVerbosity::Small,
+                            UiVerbosity::List,
                             query,
                             db,
                             entity_path,

--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -5,7 +5,7 @@
 use re_entity_db::{EntityTree, InstancePath};
 use re_log_types::{ApplicationId, ComponentPath, EntityPath, TimeInt, Timeline};
 use re_ui::{icons, SyntaxHighlighting};
-use re_viewer_context::{HoverHighlight, Item, SpaceViewId, UiVerbosity, ViewerContext};
+use re_viewer_context::{HoverHighlight, Item, SpaceViewId, UiContext, ViewerContext};
 
 use super::DataUi;
 
@@ -535,7 +535,7 @@ pub fn instance_hover_card_ui(
         // TODO(emilk): per-component stats
     }
 
-    instance_path.data_ui(ctx, ui, UiVerbosity::Tooltip, query, db);
+    instance_path.data_ui(ctx, ui, UiContext::Tooltip, query, db);
 }
 
 /// Displays the "hover card" (i.e. big tooltip) for an entity.
@@ -569,7 +569,7 @@ pub fn app_id_button_ui(
         app_id.data_ui(
             ctx,
             ui,
-            re_viewer_context::UiVerbosity::Tooltip,
+            re_viewer_context::UiContext::Tooltip,
             &ctx.current_query(), // unused
             ctx.recording(),      // unused
         );
@@ -597,7 +597,7 @@ pub fn data_source_button_ui(
         data_source.data_ui(
             ctx,
             ui,
-            re_viewer_context::UiVerbosity::Tooltip,
+            re_viewer_context::UiContext::Tooltip,
             &ctx.current_query(),
             ctx.recording(), // unused
         );
@@ -700,7 +700,7 @@ pub fn entity_db_button_ui(
         entity_db.data_ui(
             ctx,
             ui,
-            re_viewer_context::UiVerbosity::Tooltip,
+            re_viewer_context::UiContext::Tooltip,
             &ctx.current_query(),
             entity_db,
         );

--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -535,7 +535,7 @@ pub fn instance_hover_card_ui(
         // TODO(emilk): per-component stats
     }
 
-    instance_path.data_ui(ctx, ui, UiVerbosity::Reduced, query, db);
+    instance_path.data_ui(ctx, ui, UiVerbosity::Tooltip, query, db);
 }
 
 /// Displays the "hover card" (i.e. big tooltip) for an entity.
@@ -569,7 +569,7 @@ pub fn app_id_button_ui(
         app_id.data_ui(
             ctx,
             ui,
-            re_viewer_context::UiVerbosity::Reduced,
+            re_viewer_context::UiVerbosity::Tooltip,
             &ctx.current_query(), // unused
             ctx.recording(),      // unused
         );
@@ -597,7 +597,7 @@ pub fn data_source_button_ui(
         data_source.data_ui(
             ctx,
             ui,
-            re_viewer_context::UiVerbosity::Reduced,
+            re_viewer_context::UiVerbosity::Tooltip,
             &ctx.current_query(),
             ctx.recording(), // unused
         );
@@ -700,7 +700,7 @@ pub fn entity_db_button_ui(
         entity_db.data_ui(
             ctx,
             ui,
-            re_viewer_context::UiVerbosity::Reduced,
+            re_viewer_context::UiVerbosity::Tooltip,
             &ctx.current_query(),
             entity_db,
         );

--- a/crates/re_data_ui/src/item_ui.rs
+++ b/crates/re_data_ui/src/item_ui.rs
@@ -5,7 +5,7 @@
 use re_entity_db::{EntityTree, InstancePath};
 use re_log_types::{ApplicationId, ComponentPath, EntityPath, TimeInt, Timeline};
 use re_ui::{icons, SyntaxHighlighting};
-use re_viewer_context::{HoverHighlight, Item, SpaceViewId, UiContext, ViewerContext};
+use re_viewer_context::{HoverHighlight, Item, SpaceViewId, UiLayout, ViewerContext};
 
 use super::DataUi;
 
@@ -535,7 +535,7 @@ pub fn instance_hover_card_ui(
         // TODO(emilk): per-component stats
     }
 
-    instance_path.data_ui(ctx, ui, UiContext::Tooltip, query, db);
+    instance_path.data_ui(ctx, ui, UiLayout::Tooltip, query, db);
 }
 
 /// Displays the "hover card" (i.e. big tooltip) for an entity.
@@ -569,7 +569,7 @@ pub fn app_id_button_ui(
         app_id.data_ui(
             ctx,
             ui,
-            re_viewer_context::UiContext::Tooltip,
+            re_viewer_context::UiLayout::Tooltip,
             &ctx.current_query(), // unused
             ctx.recording(),      // unused
         );
@@ -597,7 +597,7 @@ pub fn data_source_button_ui(
         data_source.data_ui(
             ctx,
             ui,
-            re_viewer_context::UiContext::Tooltip,
+            re_viewer_context::UiLayout::Tooltip,
             &ctx.current_query(),
             ctx.recording(), // unused
         );
@@ -700,7 +700,7 @@ pub fn entity_db_button_ui(
         entity_db.data_ui(
             ctx,
             ui,
-            re_viewer_context::UiContext::Tooltip,
+            re_viewer_context::UiLayout::Tooltip,
             &ctx.current_query(),
             entity_db,
         );

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -139,11 +139,13 @@ impl DataUi for [DataCell] {
         sorted.sort_by_key(|cb| cb.component_name());
 
         match verbosity {
-            UiVerbosity::Small => {
+            UiVerbosity::List => {
                 ui.label(sorted.iter().map(format_cell).join(", "));
             }
 
-            UiVerbosity::Full | UiVerbosity::LimitHeight | UiVerbosity::Reduced => {
+            UiVerbosity::SelectionPanelFull
+            | UiVerbosity::SelectionPanelLimitHeight
+            | UiVerbosity::Tooltip => {
                 ui.vertical(|ui| {
                     for component_bundle in &sorted {
                         ui.label(format_cell(component_bundle));
@@ -181,26 +183,26 @@ pub fn annotations(
 /// Build an egui table and configure it for the given verbosity.
 ///
 /// Note that the caller is responsible for strictly limiting the number of displayed rows for
-/// [`UiVerbosity::Small`] and [`UiVerbosity::Reduced`], as the table will not scroll.
+/// [`UiVerbosity::List`] and [`UiVerbosity::Tooltip`], as the table will not scroll.
 pub fn table_for_verbosity(
     verbosity: UiVerbosity,
     ui: &mut egui::Ui,
 ) -> egui_extras::TableBuilder<'_> {
     let table = egui_extras::TableBuilder::new(ui);
     match verbosity {
-        UiVerbosity::Small | UiVerbosity::Reduced => {
+        UiVerbosity::List | UiVerbosity::Tooltip => {
             // Be as small as possible in the hover tooltips. No scrolling related configuration, as
             // the content itself must be limited (scrolling is not possible in tooltips).
             table.auto_shrink([true, true])
         }
-        UiVerbosity::LimitHeight => {
+        UiVerbosity::SelectionPanelLimitHeight => {
             // Don't take too much vertical space to leave room for other selected items.
             table
                 .auto_shrink([false, true])
                 .vscroll(true)
                 .max_scroll_height(100.0)
         }
-        UiVerbosity::Full => {
+        UiVerbosity::SelectionPanelFull => {
             // We're alone in the selection panel. Let the outer ScrollArea do the work.
             table.auto_shrink([false, true]).vscroll(false)
         }

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 
 use re_log_types::{DataCell, EntityPath, TimePoint};
 use re_types::ComponentName;
-use re_viewer_context::{UiContext, ViewerContext};
+use re_viewer_context::{UiLayout, ViewerContext};
 
 mod annotation_context;
 mod app_id;
@@ -59,7 +59,7 @@ pub trait DataUi {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     );
@@ -74,7 +74,7 @@ pub trait EntityDataUi {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         entity_path: &EntityPath,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
@@ -89,7 +89,7 @@ where
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         entity_path: &EntityPath,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
@@ -97,7 +97,7 @@ where
         // This ensures that UI state is maintained per entity. For example, the collapsed state for
         // `AnnotationContext` component is not saved by all instances of the component.
         ui.push_id(entity_path.hash(), |ui| {
-            self.data_ui(ctx, ui, ui_context, query, db);
+            self.data_ui(ctx, ui, ui_layout, query, db);
         });
     }
 }
@@ -109,7 +109,7 @@ impl DataUi for TimePoint {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_context: UiContext,
+        _ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -131,21 +131,21 @@ impl DataUi for [DataCell] {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
         let mut sorted = self.to_vec();
         sorted.sort_by_key(|cb| cb.component_name());
 
-        match ui_context {
-            UiContext::List => {
+        match ui_layout {
+            UiLayout::List => {
                 ui.label(sorted.iter().map(format_cell).join(", "));
             }
 
-            UiContext::SelectionPanelFull
-            | UiContext::SelectionPanelLimitHeight
-            | UiContext::Tooltip => {
+            UiLayout::SelectionPanelFull
+            | UiLayout::SelectionPanelLimitHeight
+            | UiLayout::Tooltip => {
                 ui.vertical(|ui| {
                     for component_bundle in &sorted {
                         ui.label(format_cell(component_bundle));
@@ -183,26 +183,26 @@ pub fn annotations(
 /// Build an egui table and configure it for the given UI context.
 ///
 /// Note that the caller is responsible for strictly limiting the number of displayed rows for
-/// [`UiContext::List`] and [`UiContext::Tooltip`], as the table will not scroll.
-pub fn table_for_ui_context(
-    ui_context: UiContext,
+/// [`UiLayout::List`] and [`UiLayout::Tooltip`], as the table will not scroll.
+pub fn table_for_ui_layout(
+    ui_layout: UiLayout,
     ui: &mut egui::Ui,
 ) -> egui_extras::TableBuilder<'_> {
     let table = egui_extras::TableBuilder::new(ui);
-    match ui_context {
-        UiContext::List | UiContext::Tooltip => {
+    match ui_layout {
+        UiLayout::List | UiLayout::Tooltip => {
             // Be as small as possible in the hover tooltips. No scrolling related configuration, as
             // the content itself must be limited (scrolling is not possible in tooltips).
             table.auto_shrink([true, true])
         }
-        UiContext::SelectionPanelLimitHeight => {
+        UiLayout::SelectionPanelLimitHeight => {
             // Don't take too much vertical space to leave room for other selected items.
             table
                 .auto_shrink([false, true])
                 .vscroll(true)
                 .max_scroll_height(100.0)
         }
-        UiContext::SelectionPanelFull => {
+        UiLayout::SelectionPanelFull => {
             // We're alone in the selection panel. Let the outer ScrollArea do the work.
             table.auto_shrink([false, true]).vscroll(false)
         }

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 
 use re_log_types::{DataCell, EntityPath, TimePoint};
 use re_types::ComponentName;
-use re_viewer_context::{UiVerbosity, ViewerContext};
+use re_viewer_context::{UiContext, ViewerContext};
 
 mod annotation_context;
 mod app_id;
@@ -59,7 +59,7 @@ pub trait DataUi {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     );
@@ -74,7 +74,7 @@ pub trait EntityDataUi {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         entity_path: &EntityPath,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
@@ -89,15 +89,15 @@ where
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
-        entity: &EntityPath,
+        ui_context: UiContext,
+        entity_path: &EntityPath,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
         // This ensures that UI state is maintained per entity. For example, the collapsed state for
         // `AnnotationContext` component is not saved by all instances of the component.
-        ui.push_id(entity.hash(), |ui| {
-            self.data_ui(ctx, ui, verbosity, query, db);
+        ui.push_id(entity_path.hash(), |ui| {
+            self.data_ui(ctx, ui, ui_context, query, db);
         });
     }
 }
@@ -109,7 +109,7 @@ impl DataUi for TimePoint {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _verbosity: UiVerbosity,
+        _ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -131,21 +131,21 @@ impl DataUi for [DataCell] {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
         let mut sorted = self.to_vec();
         sorted.sort_by_key(|cb| cb.component_name());
 
-        match verbosity {
-            UiVerbosity::List => {
+        match ui_context {
+            UiContext::List => {
                 ui.label(sorted.iter().map(format_cell).join(", "));
             }
 
-            UiVerbosity::SelectionPanelFull
-            | UiVerbosity::SelectionPanelLimitHeight
-            | UiVerbosity::Tooltip => {
+            UiContext::SelectionPanelFull
+            | UiContext::SelectionPanelLimitHeight
+            | UiContext::Tooltip => {
                 ui.vertical(|ui| {
                     for component_bundle in &sorted {
                         ui.label(format_cell(component_bundle));
@@ -180,29 +180,29 @@ pub fn annotations(
 
 // ---------------------------------------------------------------------------
 
-/// Build an egui table and configure it for the given verbosity.
+/// Build an egui table and configure it for the given UI context.
 ///
 /// Note that the caller is responsible for strictly limiting the number of displayed rows for
-/// [`UiVerbosity::List`] and [`UiVerbosity::Tooltip`], as the table will not scroll.
-pub fn table_for_verbosity(
-    verbosity: UiVerbosity,
+/// [`UiContext::List`] and [`UiContext::Tooltip`], as the table will not scroll.
+pub fn table_for_ui_context(
+    ui_context: UiContext,
     ui: &mut egui::Ui,
 ) -> egui_extras::TableBuilder<'_> {
     let table = egui_extras::TableBuilder::new(ui);
-    match verbosity {
-        UiVerbosity::List | UiVerbosity::Tooltip => {
+    match ui_context {
+        UiContext::List | UiContext::Tooltip => {
             // Be as small as possible in the hover tooltips. No scrolling related configuration, as
             // the content itself must be limited (scrolling is not possible in tooltips).
             table.auto_shrink([true, true])
         }
-        UiVerbosity::SelectionPanelLimitHeight => {
+        UiContext::SelectionPanelLimitHeight => {
             // Don't take too much vertical space to leave room for other selected items.
             table
                 .auto_shrink([false, true])
                 .vscroll(true)
                 .max_scroll_height(100.0)
         }
-        UiVerbosity::SelectionPanelFull => {
+        UiContext::SelectionPanelFull => {
             // We're alone in the selection panel. Let the outer ScrollArea do the work.
             table.auto_shrink([false, true]).vscroll(false)
         }

--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -1,7 +1,7 @@
 use re_log_types::{
     ArrowMsg, BlueprintActivationCommand, DataTable, LogMsg, SetStoreInfo, StoreInfo,
 };
-use re_viewer_context::{UiContext, ViewerContext};
+use re_viewer_context::{UiLayout, ViewerContext};
 
 use super::DataUi;
 use crate::item_ui;
@@ -11,13 +11,13 @@ impl DataUi for LogMsg {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
         match self {
-            LogMsg::SetStoreInfo(msg) => msg.data_ui(ctx, ui, ui_context, query, db),
-            LogMsg::ArrowMsg(_, msg) => msg.data_ui(ctx, ui, ui_context, query, db),
+            LogMsg::SetStoreInfo(msg) => msg.data_ui(ctx, ui, ui_layout, query, db),
+            LogMsg::ArrowMsg(_, msg) => msg.data_ui(ctx, ui, ui_layout, query, db),
             LogMsg::BlueprintActivationCommand(BlueprintActivationCommand {
                 blueprint_id,
                 make_active,
@@ -36,7 +36,7 @@ impl DataUi for SetStoreInfo {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_context: UiContext,
+        _ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -93,7 +93,7 @@ impl DataUi for ArrowMsg {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
@@ -118,11 +118,11 @@ impl DataUi for ArrowMsg {
                         ui.end_row();
 
                         ui.monospace("time_point:");
-                        row.timepoint().data_ui(ctx, ui, ui_context, query, db);
+                        row.timepoint().data_ui(ctx, ui, ui_layout, query, db);
                         ui.end_row();
 
                         ui.monospace("components:");
-                        row.cells().data_ui(ctx, ui, ui_context, query, db);
+                        row.cells().data_ui(ctx, ui, ui_layout, query, db);
                         ui.end_row();
                     });
                 }

--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -1,7 +1,7 @@
 use re_log_types::{
     ArrowMsg, BlueprintActivationCommand, DataTable, LogMsg, SetStoreInfo, StoreInfo,
 };
-use re_viewer_context::{UiVerbosity, ViewerContext};
+use re_viewer_context::{UiContext, ViewerContext};
 
 use super::DataUi;
 use crate::item_ui;
@@ -11,13 +11,13 @@ impl DataUi for LogMsg {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
         match self {
-            LogMsg::SetStoreInfo(msg) => msg.data_ui(ctx, ui, verbosity, query, db),
-            LogMsg::ArrowMsg(_, msg) => msg.data_ui(ctx, ui, verbosity, query, db),
+            LogMsg::SetStoreInfo(msg) => msg.data_ui(ctx, ui, ui_context, query, db),
+            LogMsg::ArrowMsg(_, msg) => msg.data_ui(ctx, ui, ui_context, query, db),
             LogMsg::BlueprintActivationCommand(BlueprintActivationCommand {
                 blueprint_id,
                 make_active,
@@ -36,7 +36,7 @@ impl DataUi for SetStoreInfo {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _verbosity: UiVerbosity,
+        _ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -93,7 +93,7 @@ impl DataUi for ArrowMsg {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
@@ -118,11 +118,11 @@ impl DataUi for ArrowMsg {
                         ui.end_row();
 
                         ui.monospace("time_point:");
-                        row.timepoint().data_ui(ctx, ui, verbosity, query, db);
+                        row.timepoint().data_ui(ctx, ui, ui_context, query, db);
                         ui.end_row();
 
                         ui.monospace("components:");
-                        row.cells().data_ui(ctx, ui, verbosity, query, db);
+                        row.cells().data_ui(ctx, ui, ui_context, query, db);
                         ui.end_row();
                     });
                 }

--- a/crates/re_data_ui/src/material.rs
+++ b/crates/re_data_ui/src/material.rs
@@ -21,10 +21,10 @@ impl DataUi for Material {
         };
 
         match verbosity {
-            UiVerbosity::Small | UiVerbosity::Reduced => {
+            UiVerbosity::List | UiVerbosity::Tooltip => {
                 show_optional_albedo_factor(ui);
             }
-            UiVerbosity::Full | UiVerbosity::LimitHeight => {
+            UiVerbosity::SelectionPanelFull | UiVerbosity::SelectionPanelLimitHeight => {
                 egui::Grid::new("material").num_columns(2).show(ui, |ui| {
                     ui.label("albedo_factor");
                     show_optional_albedo_factor(ui);

--- a/crates/re_data_ui/src/material.rs
+++ b/crates/re_data_ui/src/material.rs
@@ -1,5 +1,5 @@
 use re_types::components::{Color, Material};
-use re_viewer_context::{UiVerbosity, ViewerContext};
+use re_viewer_context::{UiContext, ViewerContext};
 
 use crate::DataUi;
 
@@ -8,23 +8,23 @@ impl DataUi for Material {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
         let show_optional_albedo_factor = |ui: &mut egui::Ui| {
             if let Some(albedo_factor) = self.albedo_factor {
-                Color(albedo_factor).data_ui(ctx, ui, verbosity, query, db);
+                Color(albedo_factor).data_ui(ctx, ui, ui_context, query, db);
             } else {
                 ui.weak("(empty)");
             }
         };
 
-        match verbosity {
-            UiVerbosity::List | UiVerbosity::Tooltip => {
+        match ui_context {
+            UiContext::List | UiContext::Tooltip => {
                 show_optional_albedo_factor(ui);
             }
-            UiVerbosity::SelectionPanelFull | UiVerbosity::SelectionPanelLimitHeight => {
+            UiContext::SelectionPanelFull | UiContext::SelectionPanelLimitHeight => {
                 egui::Grid::new("material").num_columns(2).show(ui, |ui| {
                     ui.label("albedo_factor");
                     show_optional_albedo_factor(ui);

--- a/crates/re_data_ui/src/material.rs
+++ b/crates/re_data_ui/src/material.rs
@@ -1,5 +1,5 @@
 use re_types::components::{Color, Material};
-use re_viewer_context::{UiContext, ViewerContext};
+use re_viewer_context::{UiLayout, ViewerContext};
 
 use crate::DataUi;
 
@@ -8,23 +8,23 @@ impl DataUi for Material {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
         let show_optional_albedo_factor = |ui: &mut egui::Ui| {
             if let Some(albedo_factor) = self.albedo_factor {
-                Color(albedo_factor).data_ui(ctx, ui, ui_context, query, db);
+                Color(albedo_factor).data_ui(ctx, ui, ui_layout, query, db);
             } else {
                 ui.weak("(empty)");
             }
         };
 
-        match ui_context {
-            UiContext::List | UiContext::Tooltip => {
+        match ui_layout {
+            UiLayout::List | UiLayout::Tooltip => {
                 show_optional_albedo_factor(ui);
             }
-            UiContext::SelectionPanelFull | UiContext::SelectionPanelLimitHeight => {
+            UiLayout::SelectionPanelFull | UiLayout::SelectionPanelLimitHeight => {
                 egui::Grid::new("material").num_columns(2).show(ui, |ui| {
                     ui.label("albedo_factor");
                     show_optional_albedo_factor(ui);

--- a/crates/re_data_ui/src/pinhole.rs
+++ b/crates/re_data_ui/src/pinhole.rs
@@ -1,5 +1,5 @@
 use re_types::components::{PinholeProjection, Resolution};
-use re_viewer_context::{UiVerbosity, ViewerContext};
+use re_viewer_context::{UiContext, ViewerContext};
 
 use crate::DataUi;
 
@@ -8,11 +8,11 @@ impl DataUi for PinholeProjection {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
-        if verbosity == UiVerbosity::List {
+        if ui_context == UiContext::List {
             // See if this is a trivial pinhole, and can be displayed as such:
             let fl = self.focal_length_in_pixels();
             let pp = self.principal_point();
@@ -24,12 +24,12 @@ impl DataUi for PinholeProjection {
                 };
 
                 ui.label(format!("Focal length: {fl}\nPrincipal point: {pp}"))
-                    .on_hover_ui(|ui| self.data_ui(ctx, ui, UiVerbosity::Tooltip, query, db));
+                    .on_hover_ui(|ui| self.data_ui(ctx, ui, UiContext::Tooltip, query, db));
                 return;
             }
         }
 
-        self.0.data_ui(ctx, ui, verbosity, query, db);
+        self.0.data_ui(ctx, ui, ui_context, query, db);
     }
 }
 
@@ -38,7 +38,7 @@ impl DataUi for Resolution {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _verbosity: UiVerbosity,
+        _ui_context: UiContext,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {

--- a/crates/re_data_ui/src/pinhole.rs
+++ b/crates/re_data_ui/src/pinhole.rs
@@ -12,7 +12,7 @@ impl DataUi for PinholeProjection {
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
-        if verbosity == UiVerbosity::Small {
+        if verbosity == UiVerbosity::List {
             // See if this is a trivial pinhole, and can be displayed as such:
             let fl = self.focal_length_in_pixels();
             let pp = self.principal_point();
@@ -24,7 +24,7 @@ impl DataUi for PinholeProjection {
                 };
 
                 ui.label(format!("Focal length: {fl}\nPrincipal point: {pp}"))
-                    .on_hover_ui(|ui| self.data_ui(ctx, ui, UiVerbosity::Reduced, query, db));
+                    .on_hover_ui(|ui| self.data_ui(ctx, ui, UiVerbosity::Tooltip, query, db));
                 return;
             }
         }

--- a/crates/re_data_ui/src/pinhole.rs
+++ b/crates/re_data_ui/src/pinhole.rs
@@ -1,5 +1,5 @@
 use re_types::components::{PinholeProjection, Resolution};
-use re_viewer_context::{UiContext, ViewerContext};
+use re_viewer_context::{UiLayout, ViewerContext};
 
 use crate::DataUi;
 
@@ -8,11 +8,11 @@ impl DataUi for PinholeProjection {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
-        if ui_context == UiContext::List {
+        if ui_layout == UiLayout::List {
             // See if this is a trivial pinhole, and can be displayed as such:
             let fl = self.focal_length_in_pixels();
             let pp = self.principal_point();
@@ -24,12 +24,12 @@ impl DataUi for PinholeProjection {
                 };
 
                 ui.label(format!("Focal length: {fl}\nPrincipal point: {pp}"))
-                    .on_hover_ui(|ui| self.data_ui(ctx, ui, UiContext::Tooltip, query, db));
+                    .on_hover_ui(|ui| self.data_ui(ctx, ui, UiLayout::Tooltip, query, db));
                 return;
             }
         }
 
-        self.0.data_ui(ctx, ui, ui_context, query, db);
+        self.0.data_ui(ctx, ui, ui_layout, query, db);
     }
 }
 
@@ -38,7 +38,7 @@ impl DataUi for Resolution {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_context: UiContext,
+        _ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {

--- a/crates/re_data_ui/src/rotation3d.rs
+++ b/crates/re_data_ui/src/rotation3d.rs
@@ -2,7 +2,7 @@ use re_types::{
     components,
     datatypes::{self, Angle, RotationAxisAngle},
 };
-use re_viewer_context::{UiVerbosity, ViewerContext};
+use re_viewer_context::{UiContext, ViewerContext};
 
 use crate::DataUi;
 
@@ -11,11 +11,11 @@ impl DataUi for components::Rotation3D {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
-        self.0.data_ui(ctx, ui, verbosity, query, db);
+        self.0.data_ui(ctx, ui, ui_context, query, db);
     }
 }
 
@@ -24,7 +24,7 @@ impl DataUi for datatypes::Rotation3D {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
@@ -36,7 +36,7 @@ impl DataUi for datatypes::Rotation3D {
             datatypes::Rotation3D::AxisAngle(RotationAxisAngle { axis, angle }) => {
                 egui::Grid::new("axis_angle").num_columns(2).show(ui, |ui| {
                     ui.label("axis");
-                    axis.data_ui(ctx, ui, verbosity, query, db);
+                    axis.data_ui(ctx, ui, ui_context, query, db);
                     ui.end_row();
 
                     ui.label("angle");

--- a/crates/re_data_ui/src/rotation3d.rs
+++ b/crates/re_data_ui/src/rotation3d.rs
@@ -2,7 +2,7 @@ use re_types::{
     components,
     datatypes::{self, Angle, RotationAxisAngle},
 };
-use re_viewer_context::{UiContext, ViewerContext};
+use re_viewer_context::{UiLayout, ViewerContext};
 
 use crate::DataUi;
 
@@ -11,11 +11,11 @@ impl DataUi for components::Rotation3D {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
-        self.0.data_ui(ctx, ui, ui_context, query, db);
+        self.0.data_ui(ctx, ui, ui_layout, query, db);
     }
 }
 
@@ -24,7 +24,7 @@ impl DataUi for datatypes::Rotation3D {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
@@ -36,7 +36,7 @@ impl DataUi for datatypes::Rotation3D {
             datatypes::Rotation3D::AxisAngle(RotationAxisAngle { axis, angle }) => {
                 egui::Grid::new("axis_angle").num_columns(2).show(ui, |ui| {
                     ui.label("axis");
-                    axis.data_ui(ctx, ui, ui_context, query, db);
+                    axis.data_ui(ctx, ui, ui_layout, query, db);
                     ui.end_row();
 
                     ui.label("angle");

--- a/crates/re_data_ui/src/store_id.rs
+++ b/crates/re_data_ui/src/store_id.rs
@@ -1,14 +1,16 @@
+use re_viewer_context::{UiContext, ViewerContext};
+
 impl crate::DataUi for re_log_types::StoreId {
     fn data_ui(
         &self,
-        ctx: &re_viewer_context::ViewerContext<'_>,
+        ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: re_viewer_context::UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
         if let Some(entity_db) = ctx.store_context.bundle.get(self) {
-            entity_db.data_ui(ctx, ui, verbosity, query, db);
+            entity_db.data_ui(ctx, ui, ui_context, query, db);
         } else {
             ui.label(format!("{} ID {} (not found)", self.kind, self.id));
         }

--- a/crates/re_data_ui/src/store_id.rs
+++ b/crates/re_data_ui/src/store_id.rs
@@ -1,16 +1,16 @@
-use re_viewer_context::{UiContext, ViewerContext};
+use re_viewer_context::{UiLayout, ViewerContext};
 
 impl crate::DataUi for re_log_types::StoreId {
     fn data_ui(
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
         if let Some(entity_db) = ctx.store_context.bundle.get(self) {
-            entity_db.data_ui(ctx, ui, ui_context, query, db);
+            entity_db.data_ui(ctx, ui, ui_layout, query, db);
         } else {
             ui.label(format!("{} ID {} (not found)", self.kind, self.id));
         }

--- a/crates/re_data_ui/src/transform3d.rs
+++ b/crates/re_data_ui/src/transform3d.rs
@@ -14,14 +14,16 @@ impl DataUi for re_types::components::Transform3D {
         db: &re_entity_db::EntityDb,
     ) {
         match verbosity {
-            UiVerbosity::Small => {
+            UiVerbosity::List => {
                 // TODO(andreas): Preview some information instead of just a label with hover ui.
                 ui.label("3D transform").on_hover_ui(|ui| {
-                    self.data_ui(ctx, ui, UiVerbosity::LimitHeight, query, db);
+                    self.data_ui(ctx, ui, UiVerbosity::SelectionPanelLimitHeight, query, db);
                 });
             }
 
-            UiVerbosity::Full | UiVerbosity::LimitHeight | UiVerbosity::Reduced => {
+            UiVerbosity::SelectionPanelFull
+            | UiVerbosity::SelectionPanelLimitHeight
+            | UiVerbosity::Tooltip => {
                 let from_parent = match &self.0 {
                     Transform3D::TranslationRotationScale(t) => t.from_parent,
                     Transform3D::TranslationAndMat3x3(t) => t.from_parent,
@@ -69,13 +71,15 @@ impl DataUi for Transform3D {
         db: &re_entity_db::EntityDb,
     ) {
         match verbosity {
-            UiVerbosity::Small => {
+            UiVerbosity::List => {
                 ui.label("3D transform").on_hover_ui(|ui| {
-                    self.data_ui(ctx, ui, UiVerbosity::LimitHeight, query, db);
+                    self.data_ui(ctx, ui, UiVerbosity::SelectionPanelLimitHeight, query, db);
                 });
             }
 
-            UiVerbosity::Full | UiVerbosity::LimitHeight | UiVerbosity::Reduced => match self {
+            UiVerbosity::SelectionPanelFull
+            | UiVerbosity::SelectionPanelLimitHeight
+            | UiVerbosity::Tooltip => match self {
                 Transform3D::TranslationAndMat3x3(translation_matrix) => {
                     translation_matrix.data_ui(ctx, ui, verbosity, query, db);
                 }

--- a/crates/re_data_ui/src/transform3d.rs
+++ b/crates/re_data_ui/src/transform3d.rs
@@ -1,5 +1,5 @@
 use re_types::datatypes::{Scale3D, Transform3D, TranslationAndMat3x3, TranslationRotationScale3D};
-use re_viewer_context::{UiContext, ViewerContext};
+use re_viewer_context::{UiLayout, ViewerContext};
 
 use crate::DataUi;
 
@@ -9,21 +9,21 @@ impl DataUi for re_types::components::Transform3D {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
-        match ui_context {
-            UiContext::List => {
+        match ui_layout {
+            UiLayout::List => {
                 // TODO(andreas): Preview some information instead of just a label with hover ui.
                 ui.label("3D transform").on_hover_ui(|ui| {
-                    self.data_ui(ctx, ui, UiContext::SelectionPanelLimitHeight, query, db);
+                    self.data_ui(ctx, ui, UiLayout::SelectionPanelLimitHeight, query, db);
                 });
             }
 
-            UiContext::SelectionPanelFull
-            | UiContext::SelectionPanelLimitHeight
-            | UiContext::Tooltip => {
+            UiLayout::SelectionPanelFull
+            | UiLayout::SelectionPanelLimitHeight
+            | UiLayout::Tooltip => {
                 let from_parent = match &self.0 {
                     Transform3D::TranslationRotationScale(t) => t.from_parent,
                     Transform3D::TranslationAndMat3x3(t) => t.from_parent,
@@ -38,7 +38,7 @@ impl DataUi for re_types::components::Transform3D {
                     ui.label("3D transform");
                     ui.indent("transform_repr", |ui| {
                         ui.label(dir_string);
-                        self.0.data_ui(ctx, ui, ui_context, query, db);
+                        self.0.data_ui(ctx, ui, ui_layout, query, db);
                     });
                 });
             }
@@ -52,11 +52,11 @@ impl DataUi for re_types::components::OutOfTreeTransform3D {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
-        re_types::components::Transform3D(self.0).data_ui(ctx, ui, ui_context, query, db);
+        re_types::components::Transform3D(self.0).data_ui(ctx, ui, ui_layout, query, db);
     }
 }
 
@@ -66,25 +66,25 @@ impl DataUi for Transform3D {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
-        match ui_context {
-            UiContext::List => {
+        match ui_layout {
+            UiLayout::List => {
                 ui.label("3D transform").on_hover_ui(|ui| {
-                    self.data_ui(ctx, ui, UiContext::SelectionPanelLimitHeight, query, db);
+                    self.data_ui(ctx, ui, UiLayout::SelectionPanelLimitHeight, query, db);
                 });
             }
 
-            UiContext::SelectionPanelFull
-            | UiContext::SelectionPanelLimitHeight
-            | UiContext::Tooltip => match self {
+            UiLayout::SelectionPanelFull
+            | UiLayout::SelectionPanelLimitHeight
+            | UiLayout::Tooltip => match self {
                 Transform3D::TranslationAndMat3x3(translation_matrix) => {
-                    translation_matrix.data_ui(ctx, ui, ui_context, query, db);
+                    translation_matrix.data_ui(ctx, ui, ui_layout, query, db);
                 }
                 Transform3D::TranslationRotationScale(translation_rotation_scale) => {
-                    translation_rotation_scale.data_ui(ctx, ui, ui_context, query, db);
+                    translation_rotation_scale.data_ui(ctx, ui, ui_layout, query, db);
                 }
             },
         }
@@ -96,7 +96,7 @@ impl DataUi for TranslationRotationScale3D {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
@@ -114,19 +114,19 @@ impl DataUi for TranslationRotationScale3D {
                 // We still skip zero translations though since they are typically not logged explicitly.
                 if let Some(translation) = translation {
                     ui.label("translation");
-                    translation.data_ui(ctx, ui, ui_context, query, db);
+                    translation.data_ui(ctx, ui, ui_layout, query, db);
                     ui.end_row();
                 }
 
                 if let Some(rotation) = rotation {
                     ui.label("rotation");
-                    rotation.data_ui(ctx, ui, ui_context, query, db);
+                    rotation.data_ui(ctx, ui, ui_layout, query, db);
                     ui.end_row();
                 }
 
                 if let Some(scale) = scale {
                     ui.label("scale");
-                    scale.data_ui(ctx, ui, ui_context, query, db);
+                    scale.data_ui(ctx, ui, ui_layout, query, db);
                     ui.end_row();
                 }
             });
@@ -138,7 +138,7 @@ impl DataUi for Scale3D {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
@@ -147,7 +147,7 @@ impl DataUi for Scale3D {
                 ui.label(re_format::format_f32(*scale));
             }
             Scale3D::ThreeD(v) => {
-                v.data_ui(ctx, ui, ui_context, query, db);
+                v.data_ui(ctx, ui, ui_layout, query, db);
             }
         }
     }
@@ -158,7 +158,7 @@ impl DataUi for TranslationAndMat3x3 {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
@@ -173,13 +173,13 @@ impl DataUi for TranslationAndMat3x3 {
             .show(ui, |ui| {
                 if let Some(translation) = translation {
                     ui.label("translation");
-                    translation.data_ui(ctx, ui, ui_context, query, db);
+                    translation.data_ui(ctx, ui, ui_layout, query, db);
                     ui.end_row();
                 }
 
                 if let Some(matrix) = mat3x3 {
                     ui.label("matrix");
-                    matrix.data_ui(ctx, ui, ui_context, query, db);
+                    matrix.data_ui(ctx, ui, ui_layout, query, db);
                     ui.end_row();
                 }
             });

--- a/crates/re_data_ui/src/transform3d.rs
+++ b/crates/re_data_ui/src/transform3d.rs
@@ -1,5 +1,5 @@
 use re_types::datatypes::{Scale3D, Transform3D, TranslationAndMat3x3, TranslationRotationScale3D};
-use re_viewer_context::{UiVerbosity, ViewerContext};
+use re_viewer_context::{UiContext, ViewerContext};
 
 use crate::DataUi;
 
@@ -9,21 +9,21 @@ impl DataUi for re_types::components::Transform3D {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
-        match verbosity {
-            UiVerbosity::List => {
+        match ui_context {
+            UiContext::List => {
                 // TODO(andreas): Preview some information instead of just a label with hover ui.
                 ui.label("3D transform").on_hover_ui(|ui| {
-                    self.data_ui(ctx, ui, UiVerbosity::SelectionPanelLimitHeight, query, db);
+                    self.data_ui(ctx, ui, UiContext::SelectionPanelLimitHeight, query, db);
                 });
             }
 
-            UiVerbosity::SelectionPanelFull
-            | UiVerbosity::SelectionPanelLimitHeight
-            | UiVerbosity::Tooltip => {
+            UiContext::SelectionPanelFull
+            | UiContext::SelectionPanelLimitHeight
+            | UiContext::Tooltip => {
                 let from_parent = match &self.0 {
                     Transform3D::TranslationRotationScale(t) => t.from_parent,
                     Transform3D::TranslationAndMat3x3(t) => t.from_parent,
@@ -38,7 +38,7 @@ impl DataUi for re_types::components::Transform3D {
                     ui.label("3D transform");
                     ui.indent("transform_repr", |ui| {
                         ui.label(dir_string);
-                        self.0.data_ui(ctx, ui, verbosity, query, db);
+                        self.0.data_ui(ctx, ui, ui_context, query, db);
                     });
                 });
             }
@@ -52,11 +52,11 @@ impl DataUi for re_types::components::OutOfTreeTransform3D {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
-        re_types::components::Transform3D(self.0).data_ui(ctx, ui, verbosity, query, db);
+        re_types::components::Transform3D(self.0).data_ui(ctx, ui, ui_context, query, db);
     }
 }
 
@@ -66,25 +66,25 @@ impl DataUi for Transform3D {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
-        match verbosity {
-            UiVerbosity::List => {
+        match ui_context {
+            UiContext::List => {
                 ui.label("3D transform").on_hover_ui(|ui| {
-                    self.data_ui(ctx, ui, UiVerbosity::SelectionPanelLimitHeight, query, db);
+                    self.data_ui(ctx, ui, UiContext::SelectionPanelLimitHeight, query, db);
                 });
             }
 
-            UiVerbosity::SelectionPanelFull
-            | UiVerbosity::SelectionPanelLimitHeight
-            | UiVerbosity::Tooltip => match self {
+            UiContext::SelectionPanelFull
+            | UiContext::SelectionPanelLimitHeight
+            | UiContext::Tooltip => match self {
                 Transform3D::TranslationAndMat3x3(translation_matrix) => {
-                    translation_matrix.data_ui(ctx, ui, verbosity, query, db);
+                    translation_matrix.data_ui(ctx, ui, ui_context, query, db);
                 }
                 Transform3D::TranslationRotationScale(translation_rotation_scale) => {
-                    translation_rotation_scale.data_ui(ctx, ui, verbosity, query, db);
+                    translation_rotation_scale.data_ui(ctx, ui, ui_context, query, db);
                 }
             },
         }
@@ -96,7 +96,7 @@ impl DataUi for TranslationRotationScale3D {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
@@ -114,19 +114,19 @@ impl DataUi for TranslationRotationScale3D {
                 // We still skip zero translations though since they are typically not logged explicitly.
                 if let Some(translation) = translation {
                     ui.label("translation");
-                    translation.data_ui(ctx, ui, verbosity, query, db);
+                    translation.data_ui(ctx, ui, ui_context, query, db);
                     ui.end_row();
                 }
 
                 if let Some(rotation) = rotation {
                     ui.label("rotation");
-                    rotation.data_ui(ctx, ui, verbosity, query, db);
+                    rotation.data_ui(ctx, ui, ui_context, query, db);
                     ui.end_row();
                 }
 
                 if let Some(scale) = scale {
                     ui.label("scale");
-                    scale.data_ui(ctx, ui, verbosity, query, db);
+                    scale.data_ui(ctx, ui, ui_context, query, db);
                     ui.end_row();
                 }
             });
@@ -138,7 +138,7 @@ impl DataUi for Scale3D {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
@@ -147,7 +147,7 @@ impl DataUi for Scale3D {
                 ui.label(re_format::format_f32(*scale));
             }
             Scale3D::ThreeD(v) => {
-                v.data_ui(ctx, ui, verbosity, query, db);
+                v.data_ui(ctx, ui, ui_context, query, db);
             }
         }
     }
@@ -158,7 +158,7 @@ impl DataUi for TranslationAndMat3x3 {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
@@ -173,13 +173,13 @@ impl DataUi for TranslationAndMat3x3 {
             .show(ui, |ui| {
                 if let Some(translation) = translation {
                     ui.label("translation");
-                    translation.data_ui(ctx, ui, verbosity, query, db);
+                    translation.data_ui(ctx, ui, ui_context, query, db);
                     ui.end_row();
                 }
 
                 if let Some(matrix) = mat3x3 {
                     ui.label("matrix");
-                    matrix.data_ui(ctx, ui, verbosity, query, db);
+                    matrix.data_ui(ctx, ui, ui_context, query, db);
                     ui.end_row();
                 }
             });

--- a/crates/re_space_view_dataframe/src/space_view_class.rs
+++ b/crates/re_space_view_dataframe/src/space_view_class.rs
@@ -9,7 +9,7 @@ use re_log_types::{EntityPath, Instance, Timeline};
 use re_types_core::SpaceViewClassIdentifier;
 use re_viewer_context::{
     SpaceViewClass, SpaceViewClassRegistryError, SpaceViewState, SpaceViewSystemExecutionError,
-    SystemExecutionOutput, UiVerbosity, ViewQuery, ViewerContext,
+    SystemExecutionOutput, UiContext, ViewQuery, ViewerContext,
 };
 
 use crate::visualizer_system::EmptySystem;
@@ -166,7 +166,7 @@ impl SpaceViewClass for DataframeSpaceView {
                         ctx.component_ui_registry.ui(
                             ctx,
                             ui,
-                            UiVerbosity::List,
+                            UiContext::List,
                             &latest_at_query,
                             ctx.recording(),
                             &instance.entity_path,

--- a/crates/re_space_view_dataframe/src/space_view_class.rs
+++ b/crates/re_space_view_dataframe/src/space_view_class.rs
@@ -166,7 +166,7 @@ impl SpaceViewClass for DataframeSpaceView {
                         ctx.component_ui_registry.ui(
                             ctx,
                             ui,
-                            UiVerbosity::Small,
+                            UiVerbosity::List,
                             &latest_at_query,
                             ctx.recording(),
                             &instance.entity_path,

--- a/crates/re_space_view_dataframe/src/space_view_class.rs
+++ b/crates/re_space_view_dataframe/src/space_view_class.rs
@@ -9,7 +9,7 @@ use re_log_types::{EntityPath, Instance, Timeline};
 use re_types_core::SpaceViewClassIdentifier;
 use re_viewer_context::{
     SpaceViewClass, SpaceViewClassRegistryError, SpaceViewState, SpaceViewSystemExecutionError,
-    SystemExecutionOutput, UiContext, ViewQuery, ViewerContext,
+    SystemExecutionOutput, UiLayout, ViewQuery, ViewerContext,
 };
 
 use crate::visualizer_system::EmptySystem;
@@ -166,7 +166,7 @@ impl SpaceViewClass for DataframeSpaceView {
                         ctx.component_ui_registry.ui(
                             ctx,
                             ui,
-                            UiContext::List,
+                            UiLayout::List,
                             &latest_at_query,
                             ctx.recording(),
                             &instance.entity_path,

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -14,7 +14,7 @@ use re_types::{
 use re_types::{blueprint::components::BackgroundKind, tensor_data::TensorDataMeaning};
 use re_viewer_context::{
     HoverHighlight, Item, ItemSpaceContext, SelectionHighlight, SpaceViewHighlights, SpaceViewId,
-    SpaceViewState, SpaceViewSystemExecutionError, TensorDecodeCache, TensorStatsCache, UiContext,
+    SpaceViewState, SpaceViewSystemExecutionError, TensorDecodeCache, TensorStatsCache, UiLayout,
     ViewContextCollection, ViewQuery, ViewerContext, VisualizerCollection,
 };
 
@@ -602,7 +602,7 @@ pub fn picking(
                 instance_path.data_ui(
                     ctx,
                     ui,
-                    UiContext::Tooltip,
+                    UiLayout::Tooltip,
                     &ctx.current_query(),
                     ctx.recording(),
                 );
@@ -684,7 +684,7 @@ fn image_hover_ui(
         component_path.data_ui(
             ctx,
             ui,
-            UiContext::List,
+            UiLayout::List,
             &ctx.current_query(),
             ctx.recording(),
         );
@@ -693,7 +693,7 @@ fn image_hover_ui(
         instance_path.data_ui(
             ctx,
             ui,
-            UiContext::List,
+            UiLayout::List,
             &ctx.current_query(),
             ctx.recording(),
         );

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -14,8 +14,8 @@ use re_types::{
 use re_types::{blueprint::components::BackgroundKind, tensor_data::TensorDataMeaning};
 use re_viewer_context::{
     HoverHighlight, Item, ItemSpaceContext, SelectionHighlight, SpaceViewHighlights, SpaceViewId,
-    SpaceViewState, SpaceViewSystemExecutionError, TensorDecodeCache, TensorStatsCache,
-    UiVerbosity, ViewContextCollection, ViewQuery, ViewerContext, VisualizerCollection,
+    SpaceViewState, SpaceViewSystemExecutionError, TensorDecodeCache, TensorStatsCache, UiContext,
+    ViewContextCollection, ViewQuery, ViewerContext, VisualizerCollection,
 };
 
 use crate::scene_bounding_boxes::SceneBoundingBoxes;
@@ -602,7 +602,7 @@ pub fn picking(
                 instance_path.data_ui(
                     ctx,
                     ui,
-                    UiVerbosity::Tooltip,
+                    UiContext::Tooltip,
                     &ctx.current_query(),
                     ctx.recording(),
                 );
@@ -684,7 +684,7 @@ fn image_hover_ui(
         component_path.data_ui(
             ctx,
             ui,
-            UiVerbosity::List,
+            UiContext::List,
             &ctx.current_query(),
             ctx.recording(),
         );
@@ -693,7 +693,7 @@ fn image_hover_ui(
         instance_path.data_ui(
             ctx,
             ui,
-            UiVerbosity::List,
+            UiContext::List,
             &ctx.current_query(),
             ctx.recording(),
         );

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -602,7 +602,7 @@ pub fn picking(
                 instance_path.data_ui(
                     ctx,
                     ui,
-                    UiVerbosity::Reduced,
+                    UiVerbosity::Tooltip,
                     &ctx.current_query(),
                     ctx.recording(),
                 );
@@ -684,7 +684,7 @@ fn image_hover_ui(
         component_path.data_ui(
             ctx,
             ui,
-            UiVerbosity::Small,
+            UiVerbosity::List,
             &ctx.current_query(),
             ctx.recording(),
         );
@@ -693,7 +693,7 @@ fn image_hover_ui(
         instance_path.data_ui(
             ctx,
             ui,
-            UiVerbosity::Small,
+            UiVerbosity::List,
             &ctx.current_query(),
             ctx.recording(),
         );

--- a/crates/re_time_panel/src/data_density_graph.rs
+++ b/crates/re_time_panel/src/data_density_graph.rs
@@ -11,7 +11,7 @@ use egui::{epaint::Vertex, lerp, pos2, remap, Color32, NumExt as _, Rect, Shape}
 use re_data_ui::item_ui;
 use re_entity_db::TimeHistogram;
 use re_log_types::{ComponentPath, ResolvedTimeRange, TimeReal};
-use re_viewer_context::{Item, TimeControl, UiContext, ViewerContext};
+use re_viewer_context::{Item, TimeControl, UiLayout, ViewerContext};
 
 use crate::TimePanelItem;
 
@@ -544,7 +544,7 @@ fn show_row_ids_tooltip(
 
         let query = re_data_store::LatestAtQuery::new(*time_ctrl.timeline(), time_range.max());
 
-        let ui_context = UiContext::Tooltip;
+        let ui_layout = UiLayout::Tooltip;
 
         let TimePanelItem {
             entity_path,
@@ -555,12 +555,12 @@ fn show_row_ids_tooltip(
             let component_path = ComponentPath::new(entity_path.clone(), *component_name);
             item_ui::component_path_button(ctx, ui, &component_path, db);
             ui.add_space(8.0);
-            component_path.data_ui(ctx, ui, ui_context, &query, db);
+            component_path.data_ui(ctx, ui, ui_layout, &query, db);
         } else {
             let instance_path = re_entity_db::InstancePath::entity_all(entity_path.clone());
             item_ui::instance_path_button(ctx, &query, db, ui, None, &instance_path);
             ui.add_space(8.0);
-            instance_path.data_ui(ctx, ui, ui_context, &query, db);
+            instance_path.data_ui(ctx, ui, ui_layout, &query, db);
         }
     });
 }

--- a/crates/re_time_panel/src/data_density_graph.rs
+++ b/crates/re_time_panel/src/data_density_graph.rs
@@ -11,7 +11,7 @@ use egui::{epaint::Vertex, lerp, pos2, remap, Color32, NumExt as _, Rect, Shape}
 use re_data_ui::item_ui;
 use re_entity_db::TimeHistogram;
 use re_log_types::{ComponentPath, ResolvedTimeRange, TimeReal};
-use re_viewer_context::{Item, TimeControl, UiVerbosity, ViewerContext};
+use re_viewer_context::{Item, TimeControl, UiContext, ViewerContext};
 
 use crate::TimePanelItem;
 
@@ -544,7 +544,7 @@ fn show_row_ids_tooltip(
 
         let query = re_data_store::LatestAtQuery::new(*time_ctrl.timeline(), time_range.max());
 
-        let verbosity = UiVerbosity::Tooltip;
+        let ui_context = UiContext::Tooltip;
 
         let TimePanelItem {
             entity_path,
@@ -555,12 +555,12 @@ fn show_row_ids_tooltip(
             let component_path = ComponentPath::new(entity_path.clone(), *component_name);
             item_ui::component_path_button(ctx, ui, &component_path, db);
             ui.add_space(8.0);
-            component_path.data_ui(ctx, ui, verbosity, &query, db);
+            component_path.data_ui(ctx, ui, ui_context, &query, db);
         } else {
             let instance_path = re_entity_db::InstancePath::entity_all(entity_path.clone());
             item_ui::instance_path_button(ctx, &query, db, ui, None, &instance_path);
             ui.add_space(8.0);
-            instance_path.data_ui(ctx, ui, verbosity, &query, db);
+            instance_path.data_ui(ctx, ui, ui_context, &query, db);
         }
     });
 }

--- a/crates/re_time_panel/src/data_density_graph.rs
+++ b/crates/re_time_panel/src/data_density_graph.rs
@@ -544,7 +544,7 @@ fn show_row_ids_tooltip(
 
         let query = re_data_store::LatestAtQuery::new(*time_ctrl.timeline(), time_range.max());
 
-        let verbosity = UiVerbosity::Reduced;
+        let verbosity = UiVerbosity::Tooltip;
 
         let TimePanelItem {
             entity_path,

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -22,7 +22,7 @@ use re_log_types::{
 };
 use re_ui::list_item::{ListItem, WidthAllocationMode};
 use re_viewer_context::{
-    CollapseScope, HoverHighlight, Item, RecordingConfig, TimeControl, TimeView, UiContext,
+    CollapseScope, HoverHighlight, Item, RecordingConfig, TimeControl, TimeView, UiLayout,
     ViewerContext,
 };
 use re_viewport::{context_menu_ui_for_item, SelectionUpdateBehavior, ViewportBlueprint};
@@ -787,8 +787,8 @@ impl TimePanel {
                                 *time_ctrl.timeline(),
                                 TimeInt::MAX,
                             );
-                            let ui_context = UiContext::Tooltip;
-                            component_path.data_ui(ctx, ui, ui_context, &query, entity_db);
+                            let ui_layout = UiLayout::Tooltip;
+                            component_path.data_ui(ctx, ui, ui_layout, &query, entity_db);
                         }
                     }
                 });

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -787,7 +787,7 @@ impl TimePanel {
                                 *time_ctrl.timeline(),
                                 TimeInt::MAX,
                             );
-                            let verbosity = UiVerbosity::Reduced;
+                            let verbosity = UiVerbosity::Tooltip;
                             component_path.data_ui(ctx, ui, verbosity, &query, entity_db);
                         }
                     }

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -22,7 +22,7 @@ use re_log_types::{
 };
 use re_ui::list_item::{ListItem, WidthAllocationMode};
 use re_viewer_context::{
-    CollapseScope, HoverHighlight, Item, RecordingConfig, TimeControl, TimeView, UiVerbosity,
+    CollapseScope, HoverHighlight, Item, RecordingConfig, TimeControl, TimeView, UiContext,
     ViewerContext,
 };
 use re_viewport::{context_menu_ui_for_item, SelectionUpdateBehavior, ViewportBlueprint};
@@ -787,8 +787,8 @@ impl TimePanel {
                                 *time_ctrl.timeline(),
                                 TimeInt::MAX,
                             );
-                            let verbosity = UiVerbosity::Tooltip;
-                            component_path.data_ui(ctx, ui, verbosity, &query, entity_db);
+                            let ui_context = UiContext::Tooltip;
+                            component_path.data_ui(ctx, ui, ui_context, &query, entity_db);
                         }
                     }
                 });

--- a/crates/re_viewer/src/ui/override_ui.rs
+++ b/crates/re_viewer/src/ui/override_ui.rs
@@ -8,7 +8,7 @@ use re_log_types::{DataRow, RowId, StoreKind};
 use re_space_view::{determine_visualizable_entities, SpaceViewBlueprint};
 use re_types_core::{components::VisualizerOverrides, ComponentName};
 use re_viewer_context::{
-    DataResult, OverridePath, SystemCommand, SystemCommandSender as _, UiContext,
+    DataResult, OverridePath, SystemCommand, SystemCommandSender as _, UiLayout,
     ViewSystemIdentifier, ViewerContext,
 };
 
@@ -134,7 +134,7 @@ pub fn override_ui(
                     ctx.component_ui_registry.edit_ui(
                         ctx,
                         ui,
-                        UiContext::List,
+                        UiLayout::List,
                         &query,
                         ctx.recording(),
                         entity_path_overridden,

--- a/crates/re_viewer/src/ui/override_ui.rs
+++ b/crates/re_viewer/src/ui/override_ui.rs
@@ -8,7 +8,7 @@ use re_log_types::{DataRow, RowId, StoreKind};
 use re_space_view::{determine_visualizable_entities, SpaceViewBlueprint};
 use re_types_core::{components::VisualizerOverrides, ComponentName};
 use re_viewer_context::{
-    DataResult, OverridePath, SystemCommand, SystemCommandSender as _, UiVerbosity,
+    DataResult, OverridePath, SystemCommand, SystemCommandSender as _, UiContext,
     ViewSystemIdentifier, ViewerContext,
 };
 
@@ -134,7 +134,7 @@ pub fn override_ui(
                     ctx.component_ui_registry.edit_ui(
                         ctx,
                         ui,
-                        UiVerbosity::List,
+                        UiContext::List,
                         &query,
                         ctx.recording(),
                         entity_path_overridden,

--- a/crates/re_viewer/src/ui/override_ui.rs
+++ b/crates/re_viewer/src/ui/override_ui.rs
@@ -134,7 +134,7 @@ pub fn override_ui(
                     ctx.component_ui_registry.edit_ui(
                         ctx,
                         ui,
-                        UiVerbosity::Small,
+                        UiVerbosity::List,
                         &query,
                         ctx.recording(),
                         entity_path_overridden,

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -6,7 +6,7 @@ use re_log_types::{ApplicationId, LogMsg, StoreKind};
 use re_smart_channel::{ReceiveSet, SmartChannelSource};
 use re_ui::icons;
 use re_viewer_context::{
-    Item, StoreHub, SystemCommand, SystemCommandSender, UiContext, ViewerContext,
+    Item, StoreHub, SystemCommand, SystemCommandSender, UiLayout, ViewerContext,
 };
 
 use crate::app_state::WelcomeScreenState;
@@ -223,7 +223,7 @@ fn app_and_its_recordings_ui(
         app_id.data_ui(
             ctx,
             ui,
-            UiContext::Tooltip,
+            UiLayout::Tooltip,
             &ctx.current_query(), // unused
             ctx.recording(),      // unused
         );

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -223,7 +223,7 @@ fn app_and_its_recordings_ui(
         app_id.data_ui(
             ctx,
             ui,
-            UiVerbosity::Reduced,
+            UiVerbosity::Tooltip,
             &ctx.current_query(), // unused
             ctx.recording(),      // unused
         );

--- a/crates/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/re_viewer/src/ui/recordings_panel.rs
@@ -6,7 +6,7 @@ use re_log_types::{ApplicationId, LogMsg, StoreKind};
 use re_smart_channel::{ReceiveSet, SmartChannelSource};
 use re_ui::icons;
 use re_viewer_context::{
-    Item, StoreHub, SystemCommand, SystemCommandSender, UiVerbosity, ViewerContext,
+    Item, StoreHub, SystemCommand, SystemCommandSender, UiContext, ViewerContext,
 };
 
 use crate::app_state::WelcomeScreenState;
@@ -223,7 +223,7 @@ fn app_and_its_recordings_ui(
         app_id.data_ui(
             ctx,
             ui,
-            UiVerbosity::Tooltip,
+            UiContext::Tooltip,
             &ctx.current_query(), // unused
             ctx.recording(),      // unused
         );

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -19,7 +19,7 @@ use re_ui::{icons, list_item::ListItem};
 use re_ui::{ReUi, SyntaxHighlighting as _};
 use re_viewer_context::{
     gpu_bridge::colormap_dropdown_button_ui, ContainerId, Contents, DataQueryResult,
-    HoverHighlight, Item, SpaceViewClass, SpaceViewId, UiContext, ViewerContext,
+    HoverHighlight, Item, SpaceViewClass, SpaceViewId, UiLayout, ViewerContext,
 };
 use re_viewport::{
     contents_name_style, context_menu_ui_for_item, icon_for_container_kind,
@@ -118,10 +118,10 @@ impl SelectionPanel {
         ui.add_space(-ui.spacing().item_spacing.y);
 
         let selection = ctx.selection();
-        let ui_context = if selection.len() > 1 {
-            UiContext::SelectionPanelLimitHeight
+        let ui_layout = if selection.len() > 1 {
+            UiLayout::SelectionPanelLimitHeight
         } else {
-            UiContext::SelectionPanelFull
+            UiLayout::SelectionPanelFull
         };
         for (i, item) in selection.iter_items().enumerate() {
             ui.push_id(i, |ui| {
@@ -148,7 +148,7 @@ impl SelectionPanel {
                         } else {
                             (ctx.current_query(), ctx.recording())
                         };
-                        data_ui_item.data_ui(ctx, ui, ui_context, &query, db);
+                        data_ui_item.data_ui(ctx, ui, ui_layout, &query, db);
                     });
                 }
 

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -119,9 +119,9 @@ impl SelectionPanel {
 
         let selection = ctx.selection();
         let multi_selection_verbosity = if selection.len() > 1 {
-            UiVerbosity::LimitHeight
+            UiVerbosity::SelectionPanelLimitHeight
         } else {
-            UiVerbosity::Full
+            UiVerbosity::SelectionPanelFull
         };
         for (i, item) in selection.iter_items().enumerate() {
             ui.push_id(i, |ui| {

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -19,7 +19,7 @@ use re_ui::{icons, list_item::ListItem};
 use re_ui::{ReUi, SyntaxHighlighting as _};
 use re_viewer_context::{
     gpu_bridge::colormap_dropdown_button_ui, ContainerId, Contents, DataQueryResult,
-    HoverHighlight, Item, SpaceViewClass, SpaceViewId, UiVerbosity, ViewerContext,
+    HoverHighlight, Item, SpaceViewClass, SpaceViewId, UiContext, ViewerContext,
 };
 use re_viewport::{
     contents_name_style, context_menu_ui_for_item, icon_for_container_kind,
@@ -118,10 +118,10 @@ impl SelectionPanel {
         ui.add_space(-ui.spacing().item_spacing.y);
 
         let selection = ctx.selection();
-        let multi_selection_verbosity = if selection.len() > 1 {
-            UiVerbosity::SelectionPanelLimitHeight
+        let ui_context = if selection.len() > 1 {
+            UiContext::SelectionPanelLimitHeight
         } else {
-            UiVerbosity::SelectionPanelFull
+            UiContext::SelectionPanelFull
         };
         for (i, item) in selection.iter_items().enumerate() {
             ui.push_id(i, |ui| {
@@ -148,7 +148,7 @@ impl SelectionPanel {
                         } else {
                             (ctx.current_query(), ctx.recording())
                         };
-                        data_ui_item.data_ui(ctx, ui, multi_selection_verbosity, &query, db);
+                        data_ui_item.data_ui(ctx, ui, ui_context, &query, db);
                     });
                 }
 

--- a/crates/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/re_viewer_context/src/component_ui_registry.rs
@@ -12,7 +12,9 @@ use crate::ViewerContext;
 pub enum UiLayout {
     /// Display a short summary. Used in lists.
     ///
-    /// Keep it small enough to fit on half a row. Text should truncate.
+    /// Keep it small enough to fit on half a row (i.e. the second column of a
+    /// [`re_ui::list_item2::ListItem`] with [`re_ui::list_item2::PropertyContent`]. Text should
+    /// truncate.
     List,
 
     /// Display as much information as possible in a compact way. Used for hovering/tooltips.

--- a/crates/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/re_viewer_context/src/component_ui_registry.rs
@@ -7,28 +7,32 @@ use re_types::ComponentName;
 
 use crate::ViewerContext;
 
-/// Controls how mich space we use to show the data in a component ui.
+/// Specifies the context in which the UI is used and the constraints it should follow.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum UiVerbosity {
-    /// Keep it small enough to fit on one row.
+    /// Display a short summary. Used in lists.
+    ///
+    /// Keep it small enough to fit on half a row. Text should truncate.
     List,
 
-    /// Display a reduced set, used for hovering/tooltips.
+    /// Display as much information as possible in a compact way. Used for hovering/tooltips.
     ///
-    /// Keep it under a half-dozen lines.
+    /// Keep it under a half-dozen lines. Text may wrap. Avoid interactive UI. When using a table,
+    /// use the `re_data_ui::table_for_verbosity` function.
     Tooltip,
 
-    /// Display everything as wide as available but limit height.
+    /// Display everything as wide as available but limit height. Used in the selection panel when
+    /// multiple items are selected.
     ///
-    /// This is used for example in the selection panel when multiple items are selected. When using
-    /// a Table, use the `re_data_ui::table_for_verbosity` function.
+    /// When displaying lists, wrap them in a height-limited [`egui::ScrollArea`]. When using a
+    /// table, use the `re_data_ui::table_for_verbosity` function.
     SelectionPanelLimitHeight,
 
-    /// Display everything as wide as available, without height restrictions.
+    /// Display everything as wide as available, without height restriction. Used in the selection
+    /// panel when a single item is selected.
     ///
-    /// This is used for example in the selection panel when only one item is selected. In this
-    /// case, any scrolling is handled by the selection panel itself. When using a Table, use the
-    /// `re_data_ui::table_for_verbosity` function.
+    /// The UI will be wrapped in a [`egui::ScrollArea`], so data should be fully displayed with no
+    /// restriction. When using a table, use the `re_data_ui::table_for_verbosity` function.
     SelectionPanelFull,
 }
 

--- a/crates/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/re_viewer_context/src/component_ui_registry.rs
@@ -9,7 +9,7 @@ use crate::ViewerContext;
 
 /// Specifies the context in which the UI is used and the constraints it should follow.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum UiVerbosity {
+pub enum UiContext {
     /// Display a short summary. Used in lists.
     ///
     /// Keep it small enough to fit on half a row. Text should truncate.
@@ -18,21 +18,21 @@ pub enum UiVerbosity {
     /// Display as much information as possible in a compact way. Used for hovering/tooltips.
     ///
     /// Keep it under a half-dozen lines. Text may wrap. Avoid interactive UI. When using a table,
-    /// use the `re_data_ui::table_for_verbosity` function.
+    /// use the `re_data_ui::table_for_ui_context` function.
     Tooltip,
 
     /// Display everything as wide as available but limit height. Used in the selection panel when
     /// multiple items are selected.
     ///
     /// When displaying lists, wrap them in a height-limited [`egui::ScrollArea`]. When using a
-    /// table, use the `re_data_ui::table_for_verbosity` function.
+    /// table, use the `re_data_ui::table_for_ui_context` function.
     SelectionPanelLimitHeight,
 
     /// Display everything as wide as available, without height restriction. Used in the selection
     /// panel when a single item is selected.
     ///
     /// The UI will be wrapped in a [`egui::ScrollArea`], so data should be fully displayed with no
-    /// restriction. When using a table, use the `re_data_ui::table_for_verbosity` function.
+    /// restriction. When using a table, use the `re_data_ui::table_for_ui_context` function.
     SelectionPanelFull,
 }
 
@@ -40,7 +40,7 @@ type ComponentUiCallback = Box<
     dyn Fn(
             &ViewerContext<'_>,
             &mut egui::Ui,
-            UiVerbosity,
+            UiContext,
             &LatestAtQuery,
             &EntityDb,
             &EntityPath,
@@ -54,7 +54,7 @@ type ComponentEditCallback = Box<
     dyn Fn(
             &ViewerContext<'_>,
             &mut egui::Ui,
-            UiVerbosity,
+            UiContext,
             &LatestAtQuery,
             &EntityDb,
             &EntityPath,
@@ -120,7 +120,7 @@ impl ComponentUiRegistry {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &LatestAtQuery,
         db: &EntityDb,
         entity_path: &EntityPath,
@@ -141,7 +141,7 @@ impl ComponentUiRegistry {
         (*ui_callback)(
             ctx,
             ui,
-            verbosity,
+            ui_context,
             query,
             db,
             entity_path,
@@ -156,7 +156,7 @@ impl ComponentUiRegistry {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        verbosity: UiVerbosity,
+        ui_context: UiContext,
         query: &LatestAtQuery,
         db: &EntityDb,
         entity_path: &EntityPath,
@@ -175,7 +175,7 @@ impl ComponentUiRegistry {
             (*edit_callback)(
                 ctx,
                 ui,
-                verbosity,
+                ui_context,
                 query,
                 db,
                 entity_path,
@@ -188,7 +188,7 @@ impl ComponentUiRegistry {
             self.ui(
                 ctx,
                 ui,
-                verbosity,
+                ui_context,
                 query,
                 db,
                 entity_path,

--- a/crates/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/re_viewer_context/src/component_ui_registry.rs
@@ -9,7 +9,7 @@ use crate::ViewerContext;
 
 /// Specifies the context in which the UI is used and the constraints it should follow.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum UiContext {
+pub enum UiLayout {
     /// Display a short summary. Used in lists.
     ///
     /// Keep it small enough to fit on half a row. Text should truncate.
@@ -18,21 +18,21 @@ pub enum UiContext {
     /// Display as much information as possible in a compact way. Used for hovering/tooltips.
     ///
     /// Keep it under a half-dozen lines. Text may wrap. Avoid interactive UI. When using a table,
-    /// use the `re_data_ui::table_for_ui_context` function.
+    /// use the `re_data_ui::table_for_ui_layout` function.
     Tooltip,
 
     /// Display everything as wide as available but limit height. Used in the selection panel when
     /// multiple items are selected.
     ///
     /// When displaying lists, wrap them in a height-limited [`egui::ScrollArea`]. When using a
-    /// table, use the `re_data_ui::table_for_ui_context` function.
+    /// table, use the `re_data_ui::table_for_ui_layout` function.
     SelectionPanelLimitHeight,
 
     /// Display everything as wide as available, without height restriction. Used in the selection
     /// panel when a single item is selected.
     ///
     /// The UI will be wrapped in a [`egui::ScrollArea`], so data should be fully displayed with no
-    /// restriction. When using a table, use the `re_data_ui::table_for_ui_context` function.
+    /// restriction. When using a table, use the `re_data_ui::table_for_ui_layout` function.
     SelectionPanelFull,
 }
 
@@ -40,7 +40,7 @@ type ComponentUiCallback = Box<
     dyn Fn(
             &ViewerContext<'_>,
             &mut egui::Ui,
-            UiContext,
+            UiLayout,
             &LatestAtQuery,
             &EntityDb,
             &EntityPath,
@@ -54,7 +54,7 @@ type ComponentEditCallback = Box<
     dyn Fn(
             &ViewerContext<'_>,
             &mut egui::Ui,
-            UiContext,
+            UiLayout,
             &LatestAtQuery,
             &EntityDb,
             &EntityPath,
@@ -95,7 +95,7 @@ impl ComponentUiRegistry {
 
     /// Registers how to edit a given component in the ui.
     ///
-    /// Requires two callbacks: one to provided an initial default value, and one to show the editor
+    /// Requires two callbacks: one to provide an initial default value, and one to show the editor
     /// UI and save the updated value.
     ///
     /// If the component was already registered, the new callback replaces the old one.
@@ -120,7 +120,7 @@ impl ComponentUiRegistry {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &LatestAtQuery,
         db: &EntityDb,
         entity_path: &EntityPath,
@@ -141,7 +141,7 @@ impl ComponentUiRegistry {
         (*ui_callback)(
             ctx,
             ui,
-            ui_context,
+            ui_layout,
             query,
             db,
             entity_path,
@@ -156,7 +156,7 @@ impl ComponentUiRegistry {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        ui_context: UiContext,
+        ui_layout: UiLayout,
         query: &LatestAtQuery,
         db: &EntityDb,
         entity_path: &EntityPath,
@@ -175,7 +175,7 @@ impl ComponentUiRegistry {
             (*edit_callback)(
                 ctx,
                 ui,
-                ui_context,
+                ui_layout,
                 query,
                 db,
                 entity_path,
@@ -188,7 +188,7 @@ impl ComponentUiRegistry {
             self.ui(
                 ctx,
                 ui,
-                ui_context,
+                ui_layout,
                 query,
                 db,
                 entity_path,

--- a/crates/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/re_viewer_context/src/component_ui_registry.rs
@@ -11,25 +11,25 @@ use crate::ViewerContext;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum UiVerbosity {
     /// Keep it small enough to fit on one row.
-    Small,
+    List,
 
     /// Display a reduced set, used for hovering/tooltips.
     ///
     /// Keep it under a half-dozen lines.
-    Reduced,
+    Tooltip,
 
     /// Display everything as wide as available but limit height.
     ///
     /// This is used for example in the selection panel when multiple items are selected. When using
     /// a Table, use the `re_data_ui::table_for_verbosity` function.
-    LimitHeight,
+    SelectionPanelLimitHeight,
 
     /// Display everything as wide as available, without height restrictions.
     ///
     /// This is used for example in the selection panel when only one item is selected. In this
     /// case, any scrolling is handled by the selection panel itself. When using a Table, use the
     /// `re_data_ui::table_for_verbosity` function.
-    Full,
+    SelectionPanelFull,
 }
 
 type ComponentUiCallback = Box<

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -39,7 +39,7 @@ pub use collapsed_id::{CollapseItem, CollapseScope, CollapsedId};
 pub use command_sender::{
     command_channel, CommandReceiver, CommandSender, SystemCommand, SystemCommandSender,
 };
-pub use component_ui_registry::{ComponentUiRegistry, UiVerbosity};
+pub use component_ui_registry::{ComponentUiRegistry, UiContext};
 pub use contents::{blueprint_id_to_tile_id, Contents, ContentsName};
 pub use item::Item;
 pub use query_context::{DataQueryResult, DataResultHandle, DataResultNode, DataResultTree};

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -39,7 +39,7 @@ pub use collapsed_id::{CollapseItem, CollapseScope, CollapsedId};
 pub use command_sender::{
     command_channel, CommandReceiver, CommandSender, SystemCommand, SystemCommandSender,
 };
-pub use component_ui_registry::{ComponentUiRegistry, UiContext};
+pub use component_ui_registry::{ComponentUiRegistry, UiLayout};
 pub use contents::{blueprint_id_to_tile_id, Contents, ContentsName};
 pub use item::Item;
 pub use query_context::{DataQueryResult, DataResultHandle, DataResultNode, DataResultTree};

--- a/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
@@ -278,7 +278,7 @@ fn color_space_ui(
                 instance.data_ui(
                     ctx,
                     ui,
-                    UiVerbosity::Reduced,
+                    UiVerbosity::Tooltip,
                     &ctx.current_query(),
                     ctx.recording(),
                 );

--- a/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
@@ -10,7 +10,7 @@ use re_viewer::external::{
         SpaceViewClassLayoutPriority, SpaceViewClassRegistryError, SpaceViewId,
         SpaceViewSpawnHeuristics, SpaceViewState, SpaceViewStateExt as _,
         SpaceViewSystemExecutionError, SpaceViewSystemRegistrator, SystemExecutionOutput,
-        UiVerbosity, ViewQuery, ViewerContext,
+        UiContext, ViewQuery, ViewerContext,
     },
 };
 
@@ -278,7 +278,7 @@ fn color_space_ui(
                 instance.data_ui(
                     ctx,
                     ui,
-                    UiVerbosity::Tooltip,
+                    UiContext::Tooltip,
                     &ctx.current_query(),
                     ctx.recording(),
                 );

--- a/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_space_view.rs
@@ -9,8 +9,8 @@ use re_viewer::external::{
         HoverHighlight, IdentifiedViewSystem as _, Item, SelectionHighlight, SpaceViewClass,
         SpaceViewClassLayoutPriority, SpaceViewClassRegistryError, SpaceViewId,
         SpaceViewSpawnHeuristics, SpaceViewState, SpaceViewStateExt as _,
-        SpaceViewSystemExecutionError, SpaceViewSystemRegistrator, SystemExecutionOutput,
-        UiContext, ViewQuery, ViewerContext,
+        SpaceViewSystemExecutionError, SpaceViewSystemRegistrator, SystemExecutionOutput, UiLayout,
+        ViewQuery, ViewerContext,
     },
 };
 
@@ -278,7 +278,7 @@ fn color_space_ui(
                 instance.data_ui(
                     ctx,
                     ui,
-                    UiContext::Tooltip,
+                    UiLayout::Tooltip,
                     &ctx.current_query(),
                     ctx.recording(),
                 );


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6291](https://togithub.com/rerun-io/rerun/pull/6291).



The original branch is upstream/antoine/ui-verbosity-rename