### PR TITLE
Don't automatically fall back to automatic port if web socket port is already in use, only recommend using 0 instead

### DIFF
--- a/crates/re_ws_comms/src/lib.rs
+++ b/crates/re_ws_comms/src/lib.rs
@@ -34,6 +34,9 @@ pub enum RerunServerError {
     #[error("Failed to bind to WebSocket port {0}: {1}")]
     BindFailed(RerunServerPort, std::io::Error),
 
+    #[error("Failed to bind to WebSocket port {0} since the address is already in use. Use port 0 to let the OS choose a free port.")]
+    BindFailedAddrInUse(RerunServerPort),
+
     #[error("Received an invalid message")]
     InvalidMessagePrefix,
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6296](https://togithub.com/rerun-io/rerun/pull/6296).



The original branch is upstream/andreas/fix-unvoluntary-port-reuse