### PR TITLE
Fix cmake missing rerun_c changes due to broken glob

### DIFF
--- a/crates/rerun_c/CMakeLists.txt
+++ b/crates/rerun_c/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(rerun_c STATIC IMPORTED GLOBAL)
 set_target_properties(rerun_c PROPERTIES IMPORTED_LOCATION ${RERUN_C_BUILD_ARTIFACT})
 
 # Just depend on all rust and toml files, it's hard to know which files exactly are relevant.
-file(GLOB_RECURSE LIST_DIRECTORIES FALSE RERUN_C_SOURCES "${PROJECT_SOURCE_DIR}/crates/*.rs" "${PROJECT_SOURCE_DIR}/crates/*.toml")
+file(GLOB_RECURSE RERUN_C_SOURCES LIST_DIRECTORIES FALSE "${PROJECT_SOURCE_DIR}/crates/*.rs" "${PROJECT_SOURCE_DIR}/crates/*.toml")
 add_custom_command(
     OUTPUT ${RERUN_C_BUILD_ARTIFACT}
     DEPENDS ${RERUN_C_SOURCES}


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6301](https://togithub.com/rerun-io/rerun/pull/6301).



The original branch is upstream/andreas/fix-rerun_c-cmake-glob