### PR TITLE
Increase timeout for test_multiprocessing_gc failure

### DIFF
--- a/rerun_py/tests/unit/test_multiprocessing_gc.py
+++ b/rerun_py/tests/unit/test_multiprocessing_gc.py
@@ -27,7 +27,7 @@ def test_multiprocessing_gc() -> None:
         target=task,
     )
     proc.start()
-    proc.join(1)
+    proc.join(5)
     if proc.is_alive():
         # Terminate so our test doesn't get stuck
         proc.terminate()


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6318](https://togithub.com/rerun-io/rerun/pull/6318).



The original branch is upstream/jleibs/increase_gc_test_timeout