### PR TITLE
Add support for exact width to `PropertyContent`

### DIFF
--- a/crates/re_ui/src/list_item2/scope.rs
+++ b/crates/re_ui/src/list_item2/scope.rs
@@ -280,7 +280,7 @@ pub fn list_item_scope<R>(
     };
 
     // push, run, pop
-    LayoutInfoStack::push(ui.ctx(), state.clone());
+    LayoutInfoStack::push(ui.ctx(), state);
     let result = ui
         .scope(|ui| {
             ui.spacing_mut().item_spacing.y = 0.0;


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6325](https://togithub.com/rerun-io/rerun/pull/6325).



The original branch is upstream/antoine/propcontent-exact-width