### PR TITLE
Fix lint issues on generated doc pages

### DIFF
--- a/crates/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/re_types_builder/src/codegen/docs/mod.rs
@@ -266,7 +266,7 @@ fn object_page(
     }
 
     putln!(page);
-    putln!(page, "## Api reference links");
+    putln!(page, "## API reference links");
     list_links(is_unreleased, &mut page, object);
 
     putln!(page);

--- a/docs/content/reference/types/archetypes/annotation_context.md
+++ b/docs/content/reference/types/archetypes/annotation_context.md
@@ -19,7 +19,7 @@ path.
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `AnnotationContext`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1AnnotationContext.html)
  * 🐍 [Python API docs for `AnnotationContext`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.AnnotationContext)
  * 🦀 [Rust API docs for `AnnotationContext`](https://docs.rs/rerun/latest/rerun/archetypes/struct.AnnotationContext.html)

--- a/docs/content/reference/types/archetypes/arrows2d.md
+++ b/docs/content/reference/types/archetypes/arrows2d.md
@@ -17,7 +17,7 @@ title: "Arrows2D"
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Arrows2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Arrows2D.html)
  * 🐍 [Python API docs for `Arrows2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Arrows2D)
  * 🦀 [Rust API docs for `Arrows2D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Arrows2D.html)

--- a/docs/content/reference/types/archetypes/arrows3d.md
+++ b/docs/content/reference/types/archetypes/arrows3d.md
@@ -17,7 +17,7 @@ title: "Arrows3D"
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Arrows3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Arrows3D.html)
  * 🐍 [Python API docs for `Arrows3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Arrows3D)
  * 🦀 [Rust API docs for `Arrows3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Arrows3D.html)

--- a/docs/content/reference/types/archetypes/asset3d.md
+++ b/docs/content/reference/types/archetypes/asset3d.md
@@ -17,7 +17,7 @@ A prepacked 3D asset (`.gltf`, `.glb`, `.obj`, `.stl`, etc.).
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Asset3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Asset3D.html)
  * 🐍 [Python API docs for `Asset3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Asset3D)
  * 🦀 [Rust API docs for `Asset3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Asset3D.html)

--- a/docs/content/reference/types/archetypes/bar_chart.md
+++ b/docs/content/reference/types/archetypes/bar_chart.md
@@ -16,7 +16,7 @@ The x values will be the indices of the array, and the bar heights will be the p
 ## Shown in
 * [BarChartView](../views/bar_chart_view.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `BarChart`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1BarChart.html)
  * 🐍 [Python API docs for `BarChart`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.BarChart)
  * 🦀 [Rust API docs for `BarChart`](https://docs.rs/rerun/latest/rerun/archetypes/struct.BarChart.html)

--- a/docs/content/reference/types/archetypes/boxes2d.md
+++ b/docs/content/reference/types/archetypes/boxes2d.md
@@ -17,7 +17,7 @@ title: "Boxes2D"
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Boxes2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Boxes2D.html)
  * 🐍 [Python API docs for `Boxes2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Boxes2D)
  * 🦀 [Rust API docs for `Boxes2D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Boxes2D.html)

--- a/docs/content/reference/types/archetypes/boxes3d.md
+++ b/docs/content/reference/types/archetypes/boxes3d.md
@@ -17,7 +17,7 @@ title: "Boxes3D"
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Boxes3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Boxes3D.html)
  * 🐍 [Python API docs for `Boxes3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Boxes3D)
  * 🦀 [Rust API docs for `Boxes3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Boxes3D.html)

--- a/docs/content/reference/types/archetypes/clear.md
+++ b/docs/content/reference/types/archetypes/clear.md
@@ -24,7 +24,7 @@ data (i.e. discontinuous lines).
 * [Spatial3DView](../views/spatial3d_view.md)
 * [TimeSeriesView](../views/time_series_view.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Clear`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Clear.html)
  * 🐍 [Python API docs for `Clear`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Clear)
  * 🦀 [Rust API docs for `Clear`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Clear.html)

--- a/docs/content/reference/types/archetypes/depth_image.md
+++ b/docs/content/reference/types/archetypes/depth_image.md
@@ -18,7 +18,7 @@ Each pixel corresponds to a depth value in units specified by `meter`.
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `DepthImage`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1DepthImage.html)
  * 🐍 [Python API docs for `DepthImage`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.DepthImage)
  * 🦀 [Rust API docs for `DepthImage`](https://docs.rs/rerun/latest/rerun/archetypes/struct.DepthImage.html)

--- a/docs/content/reference/types/archetypes/disconnected_space.md
+++ b/docs/content/reference/types/archetypes/disconnected_space.md
@@ -18,7 +18,7 @@ This is useful for specifying that a subgraph is independent of the rest of the 
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1DisconnectedSpace.html)
  * 🐍 [Python API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.DisconnectedSpace)
  * 🦀 [Rust API docs for `DisconnectedSpace`](https://docs.rs/rerun/latest/rerun/archetypes/struct.DisconnectedSpace.html)

--- a/docs/content/reference/types/archetypes/image.md
+++ b/docs/content/reference/types/archetypes/image.md
@@ -30,7 +30,7 @@ Using these formats can save a lot of bandwidth and memory.
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Image`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Image.html)
  * 🐍 [Python API docs for `Image`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Image)
  * 🦀 [Rust API docs for `Image`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Image.html)

--- a/docs/content/reference/types/archetypes/line_strips2d.md
+++ b/docs/content/reference/types/archetypes/line_strips2d.md
@@ -17,7 +17,7 @@ title: "LineStrips2D"
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `LineStrips2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1LineStrips2D.html)
  * 🐍 [Python API docs for `LineStrips2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.LineStrips2D)
  * 🦀 [Rust API docs for `LineStrips2D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.LineStrips2D.html)

--- a/docs/content/reference/types/archetypes/line_strips3d.md
+++ b/docs/content/reference/types/archetypes/line_strips3d.md
@@ -17,7 +17,7 @@ title: "LineStrips3D"
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `LineStrips3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1LineStrips3D.html)
  * 🐍 [Python API docs for `LineStrips3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.LineStrips3D)
  * 🦀 [Rust API docs for `LineStrips3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.LineStrips3D.html)

--- a/docs/content/reference/types/archetypes/mesh3d.md
+++ b/docs/content/reference/types/archetypes/mesh3d.md
@@ -17,7 +17,7 @@ A 3D triangle mesh as specified by its per-mesh and per-vertex properties.
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Mesh3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Mesh3D.html)
  * 🐍 [Python API docs for `Mesh3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Mesh3D)
  * 🦀 [Rust API docs for `Mesh3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Mesh3D.html)

--- a/docs/content/reference/types/archetypes/pinhole.md
+++ b/docs/content/reference/types/archetypes/pinhole.md
@@ -17,7 +17,7 @@ Camera perspective projection (a.k.a. intrinsics).
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Pinhole`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Pinhole.html)
  * 🐍 [Python API docs for `Pinhole`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Pinhole)
  * 🦀 [Rust API docs for `Pinhole`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Pinhole.html)

--- a/docs/content/reference/types/archetypes/points2d.md
+++ b/docs/content/reference/types/archetypes/points2d.md
@@ -17,7 +17,7 @@ A 2D point cloud with positions and optional colors, radii, labels, etc.
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Points2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Points2D.html)
  * 🐍 [Python API docs for `Points2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Points2D)
  * 🦀 [Rust API docs for `Points2D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Points2D.html)

--- a/docs/content/reference/types/archetypes/points3d.md
+++ b/docs/content/reference/types/archetypes/points3d.md
@@ -17,7 +17,7 @@ A 3D point cloud with positions and optional colors, radii, labels, etc.
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Points3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Points3D.html)
  * 🐍 [Python API docs for `Points3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Points3D)
  * 🦀 [Rust API docs for `Points3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Points3D.html)

--- a/docs/content/reference/types/archetypes/scalar.md
+++ b/docs/content/reference/types/archetypes/scalar.md
@@ -20,7 +20,7 @@ the plot-specific archetypes through the blueprint.
 ## Shown in
 * [TimeSeriesView](../views/time_series_view.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Scalar`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Scalar.html)
  * 🐍 [Python API docs for `Scalar`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Scalar)
  * 🦀 [Rust API docs for `Scalar`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Scalar.html)

--- a/docs/content/reference/types/archetypes/segmentation_image.md
+++ b/docs/content/reference/types/archetypes/segmentation_image.md
@@ -24,7 +24,7 @@ Leading and trailing unit-dimensions are ignored, so that
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `SegmentationImage`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1SegmentationImage.html)
  * 🐍 [Python API docs for `SegmentationImage`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.SegmentationImage)
  * 🦀 [Rust API docs for `SegmentationImage`](https://docs.rs/rerun/latest/rerun/archetypes/struct.SegmentationImage.html)

--- a/docs/content/reference/types/archetypes/series_line.md
+++ b/docs/content/reference/types/archetypes/series_line.md
@@ -16,7 +16,7 @@ the `Scalar` archetype.
 ## Shown in
 * [TimeSeriesView](../views/time_series_view.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `SeriesLine`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1SeriesLine.html)
  * 🐍 [Python API docs for `SeriesLine`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.SeriesLine)
  * 🦀 [Rust API docs for `SeriesLine`](https://docs.rs/rerun/latest/rerun/archetypes/struct.SeriesLine.html)

--- a/docs/content/reference/types/archetypes/series_point.md
+++ b/docs/content/reference/types/archetypes/series_point.md
@@ -16,7 +16,7 @@ the `Scalar` archetype.
 ## Shown in
 * [TimeSeriesView](../views/time_series_view.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `SeriesPoint`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1SeriesPoint.html)
  * 🐍 [Python API docs for `SeriesPoint`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.SeriesPoint)
  * 🦀 [Rust API docs for `SeriesPoint`](https://docs.rs/rerun/latest/rerun/archetypes/struct.SeriesPoint.html)

--- a/docs/content/reference/types/archetypes/tensor.md
+++ b/docs/content/reference/types/archetypes/tensor.md
@@ -13,7 +13,7 @@ A generic n-dimensional Tensor.
 * [TensorView](../views/tensor_view.md)
 * [BarChartView](../views/bar_chart_view.md) (for 1D tensors)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Tensor`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Tensor.html)
  * 🐍 [Python API docs for `Tensor`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Tensor)
  * 🦀 [Rust API docs for `Tensor`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Tensor.html)

--- a/docs/content/reference/types/archetypes/text_document.md
+++ b/docs/content/reference/types/archetypes/text_document.md
@@ -16,7 +16,7 @@ Supports raw text and markdown.
 ## Shown in
 * [TextDocumentView](../views/text_document_view.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `TextDocument`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1TextDocument.html)
  * 🐍 [Python API docs for `TextDocument`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.TextDocument)
  * 🦀 [Rust API docs for `TextDocument`](https://docs.rs/rerun/latest/rerun/archetypes/struct.TextDocument.html)

--- a/docs/content/reference/types/archetypes/text_log.md
+++ b/docs/content/reference/types/archetypes/text_log.md
@@ -16,7 +16,7 @@ A log entry in a text log, comprised of a text body and its log level.
 ## Shown in
 * [TextLogView](../views/text_log_view.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `TextLog`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1TextLog.html)
  * 🐍 [Python API docs for `TextLog`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.TextLog)
  * 🦀 [Rust API docs for `TextLog`](https://docs.rs/rerun/latest/rerun/archetypes/struct.TextLog.html)

--- a/docs/content/reference/types/archetypes/transform3d.md
+++ b/docs/content/reference/types/archetypes/transform3d.md
@@ -13,7 +13,7 @@ A 3D transform.
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Transform3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Transform3D.html)
  * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Transform3D)
  * 🦀 [Rust API docs for `Transform3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Transform3D.html)

--- a/docs/content/reference/types/archetypes/view_coordinates.md
+++ b/docs/content/reference/types/archetypes/view_coordinates.md
@@ -19,7 +19,7 @@ down, and the Z axis points forward.
 ## Shown in
 * [Spatial3DView](../views/spatial3d_view.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `ViewCoordinates`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1ViewCoordinates.html)
  * 🐍 [Python API docs for `ViewCoordinates`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.ViewCoordinates)
  * 🦀 [Rust API docs for `ViewCoordinates`](https://docs.rs/rerun/latest/rerun/archetypes/struct.ViewCoordinates.html)

--- a/docs/content/reference/types/components/annotation_context.md
+++ b/docs/content/reference/types/components/annotation_context.md
@@ -15,7 +15,7 @@ path.
 
 * class_map: list of [`ClassDescriptionMapElem`](../datatypes/class_description_map_elem.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `AnnotationContext`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1AnnotationContext.html)
  * 🐍 [Python API docs for `AnnotationContext`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.AnnotationContext)
  * 🦀 [Rust API docs for `AnnotationContext`](https://docs.rs/rerun/latest/rerun/components/struct.AnnotationContext.html)

--- a/docs/content/reference/types/components/blob.md
+++ b/docs/content/reference/types/components/blob.md
@@ -9,7 +9,7 @@ A binary blob of data.
 
 * data: list of `u8`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Blob`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Blob.html)
  * 🐍 [Python API docs for `Blob`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Blob)
  * 🦀 [Rust API docs for `Blob`](https://docs.rs/rerun/latest/rerun/components/struct.Blob.html)

--- a/docs/content/reference/types/components/class_id.md
+++ b/docs/content/reference/types/components/class_id.md
@@ -9,7 +9,7 @@ A 16-bit ID representing a type of semantic class.
 
 * id: [`ClassId`](../datatypes/class_id.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `ClassId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ClassId.html)
  * 🐍 [Python API docs for `ClassId`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ClassId)
  * 🦀 [Rust API docs for `ClassId`](https://docs.rs/rerun/latest/rerun/components/struct.ClassId.html)

--- a/docs/content/reference/types/components/clear_is_recursive.md
+++ b/docs/content/reference/types/components/clear_is_recursive.md
@@ -9,7 +9,7 @@ Configures how a clear operation should behave - recursive or not.
 
 * recursive: `bool`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `ClearIsRecursive`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ClearIsRecursive.html)
  * 🐍 [Python API docs for `ClearIsRecursive`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ClearIsRecursive)
  * 🦀 [Rust API docs for `ClearIsRecursive`](https://docs.rs/rerun/latest/rerun/components/struct.ClearIsRecursive.html)

--- a/docs/content/reference/types/components/color.md
+++ b/docs/content/reference/types/components/color.md
@@ -12,7 +12,7 @@ byte is `R` and the least significant byte is `A`.
 
 * rgba: [`Rgba32`](../datatypes/rgba32.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Color`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Color.html)
  * 🐍 [Python API docs for `Color`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Color)
  * 🦀 [Rust API docs for `Color`](https://docs.rs/rerun/latest/rerun/components/struct.Color.html)

--- a/docs/content/reference/types/components/depth_meter.md
+++ b/docs/content/reference/types/components/depth_meter.md
@@ -9,7 +9,7 @@ A component indicating how long a meter is, expressed in native units.
 
 * value: `f32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `DepthMeter`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DepthMeter.html)
  * 🐍 [Python API docs for `DepthMeter`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DepthMeter)
  * 🦀 [Rust API docs for `DepthMeter`](https://docs.rs/rerun/latest/rerun/components/struct.DepthMeter.html)

--- a/docs/content/reference/types/components/disconnected_space.md
+++ b/docs/content/reference/types/components/disconnected_space.md
@@ -14,7 +14,7 @@ This is useful for specifying that a subgraph is independent of the rest of the 
 
 * is_disconnected: `bool`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DisconnectedSpace.html)
  * 🐍 [Python API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DisconnectedSpace)
  * 🦀 [Rust API docs for `DisconnectedSpace`](https://docs.rs/rerun/latest/rerun/components/struct.DisconnectedSpace.html)

--- a/docs/content/reference/types/components/draw_order.md
+++ b/docs/content/reference/types/components/draw_order.md
@@ -15,7 +15,7 @@ Draw order for entities with the same draw order is generally undefined.
 
 * value: `f32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `DrawOrder`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DrawOrder.html)
  * 🐍 [Python API docs for `DrawOrder`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DrawOrder)
  * 🦀 [Rust API docs for `DrawOrder`](https://docs.rs/rerun/latest/rerun/components/struct.DrawOrder.html)

--- a/docs/content/reference/types/components/half_sizes2d.md
+++ b/docs/content/reference/types/components/half_sizes2d.md
@@ -12,7 +12,7 @@ Negative sizes indicate that the box is flipped along the respective axis, but t
 
 * xy: [`Vec2D`](../datatypes/vec2d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `HalfSizes2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1HalfSizes2D.html)
  * 🐍 [Python API docs for `HalfSizes2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.HalfSizes2D)
  * 🦀 [Rust API docs for `HalfSizes2D`](https://docs.rs/rerun/latest/rerun/components/struct.HalfSizes2D.html)

--- a/docs/content/reference/types/components/half_sizes3d.md
+++ b/docs/content/reference/types/components/half_sizes3d.md
@@ -12,7 +12,7 @@ Negative sizes indicate that the box is flipped along the respective axis, but t
 
 * xyz: [`Vec3D`](../datatypes/vec3d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `HalfSizes3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1HalfSizes3D.html)
  * 🐍 [Python API docs for `HalfSizes3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.HalfSizes3D)
  * 🦀 [Rust API docs for `HalfSizes3D`](https://docs.rs/rerun/latest/rerun/components/struct.HalfSizes3D.html)

--- a/docs/content/reference/types/components/keypoint_id.md
+++ b/docs/content/reference/types/components/keypoint_id.md
@@ -9,7 +9,7 @@ A 16-bit ID representing a type of semantic keypoint within a class.
 
 * id: [`KeypointId`](../datatypes/keypoint_id.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `KeypointId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1KeypointId.html)
  * 🐍 [Python API docs for `KeypointId`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.KeypointId)
  * 🦀 [Rust API docs for `KeypointId`](https://docs.rs/rerun/latest/rerun/components/struct.KeypointId.html)

--- a/docs/content/reference/types/components/line_strip2d.md
+++ b/docs/content/reference/types/components/line_strip2d.md
@@ -20,7 +20,7 @@ The points will be connected in order, like so:
 
 * points: list of [`Vec2D`](../datatypes/vec2d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `LineStrip2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1LineStrip2D.html)
  * 🐍 [Python API docs for `LineStrip2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.LineStrip2D)
  * 🦀 [Rust API docs for `LineStrip2D`](https://docs.rs/rerun/latest/rerun/components/struct.LineStrip2D.html)

--- a/docs/content/reference/types/components/line_strip3d.md
+++ b/docs/content/reference/types/components/line_strip3d.md
@@ -20,7 +20,7 @@ The points will be connected in order, like so:
 
 * points: list of [`Vec3D`](../datatypes/vec3d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `LineStrip3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1LineStrip3D.html)
  * 🐍 [Python API docs for `LineStrip3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.LineStrip3D)
  * 🦀 [Rust API docs for `LineStrip3D`](https://docs.rs/rerun/latest/rerun/components/struct.LineStrip3D.html)

--- a/docs/content/reference/types/components/marker_shape.md
+++ b/docs/content/reference/types/components/marker_shape.md
@@ -18,7 +18,7 @@ Shape of a marker.
 * Right
 * Asterisk
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `MarkerShape`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)
  * 🐍 [Python API docs for `MarkerShape`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MarkerShape)
  * 🦀 [Rust API docs for `MarkerShape`](https://docs.rs/rerun/latest/rerun/components/enum.MarkerShape.html)

--- a/docs/content/reference/types/components/marker_size.md
+++ b/docs/content/reference/types/components/marker_size.md
@@ -9,7 +9,7 @@ Size of a marker in UI points.
 
 * value: `f32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `MarkerSize`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1MarkerSize.html)
  * 🐍 [Python API docs for `MarkerSize`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MarkerSize)
  * 🦀 [Rust API docs for `MarkerSize`](https://docs.rs/rerun/latest/rerun/components/struct.MarkerSize.html)

--- a/docs/content/reference/types/components/material.md
+++ b/docs/content/reference/types/components/material.md
@@ -9,7 +9,7 @@ Material properties of a mesh.
 
 * material: [`Material`](../datatypes/material.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Material`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Material.html)
  * 🐍 [Python API docs for `Material`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Material)
  * 🦀 [Rust API docs for `Material`](https://docs.rs/rerun/latest/rerun/components/struct.Material.html)

--- a/docs/content/reference/types/components/media_type.md
+++ b/docs/content/reference/types/components/media_type.md
@@ -12,7 +12,7 @@ consulted at <https://www.iana.org/assignments/media-types/media-types.xhtml>.
 
 * value: [`Utf8`](../datatypes/utf8.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `MediaType`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1MediaType.html)
  * 🐍 [Python API docs for `MediaType`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MediaType)
  * 🦀 [Rust API docs for `MediaType`](https://docs.rs/rerun/latest/rerun/components/struct.MediaType.html)

--- a/docs/content/reference/types/components/name.md
+++ b/docs/content/reference/types/components/name.md
@@ -9,7 +9,7 @@ A display name, typically for an entity or a item like a plot series.
 
 * value: [`Utf8`](../datatypes/utf8.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Name`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Name.html)
  * 🐍 [Python API docs for `Name`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Name)
  * 🦀 [Rust API docs for `Name`](https://docs.rs/rerun/latest/rerun/components/struct.Name.html)

--- a/docs/content/reference/types/components/out_of_tree_transform3d.md
+++ b/docs/content/reference/types/components/out_of_tree_transform3d.md
@@ -11,7 +11,7 @@ An out-of-tree affine transform between two 3D spaces, represented in a given di
 
 * repr: [`Transform3D`](../datatypes/transform3d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `OutOfTreeTransform3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1OutOfTreeTransform3D.html)
  * 🐍 [Python API docs for `OutOfTreeTransform3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.OutOfTreeTransform3D)
  * 🦀 [Rust API docs for `OutOfTreeTransform3D`](https://docs.rs/rerun/latest/rerun/components/struct.OutOfTreeTransform3D.html)

--- a/docs/content/reference/types/components/pinhole_projection.md
+++ b/docs/content/reference/types/components/pinhole_projection.md
@@ -19,7 +19,7 @@ Example:
 
 * image_from_camera: [`Mat3x3`](../datatypes/mat3x3.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `PinholeProjection`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PinholeProjection.html)
  * 🐍 [Python API docs for `PinholeProjection`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.PinholeProjection)
  * 🦀 [Rust API docs for `PinholeProjection`](https://docs.rs/rerun/latest/rerun/components/struct.PinholeProjection.html)

--- a/docs/content/reference/types/components/position2d.md
+++ b/docs/content/reference/types/components/position2d.md
@@ -9,7 +9,7 @@ A position in 2D space.
 
 * xy: [`Vec2D`](../datatypes/vec2d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Position2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Position2D.html)
  * 🐍 [Python API docs for `Position2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Position2D)
  * 🦀 [Rust API docs for `Position2D`](https://docs.rs/rerun/latest/rerun/components/struct.Position2D.html)

--- a/docs/content/reference/types/components/position3d.md
+++ b/docs/content/reference/types/components/position3d.md
@@ -9,7 +9,7 @@ A position in 3D space.
 
 * xyz: [`Vec3D`](../datatypes/vec3d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Position3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Position3D.html)
  * 🐍 [Python API docs for `Position3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Position3D)
  * 🦀 [Rust API docs for `Position3D`](https://docs.rs/rerun/latest/rerun/components/struct.Position3D.html)

--- a/docs/content/reference/types/components/radius.md
+++ b/docs/content/reference/types/components/radius.md
@@ -9,7 +9,7 @@ A Radius component.
 
 * value: `f32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Radius`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Radius.html)
  * 🐍 [Python API docs for `Radius`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Radius)
  * 🦀 [Rust API docs for `Radius`](https://docs.rs/rerun/latest/rerun/components/struct.Radius.html)

--- a/docs/content/reference/types/components/range1d.md
+++ b/docs/content/reference/types/components/range1d.md
@@ -9,7 +9,7 @@ A 1D range, specifying a lower and upper bound.
 
 * range: [`Range1D`](../datatypes/range1d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Range1D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Range1D.html?speculative-link)
  * 🐍 [Python API docs for `Range1D`](https://ref.rerun.io/docs/python/stable/common/components?speculative-link#rerun.components.Range1D)
  * 🦀 [Rust API docs for `Range1D`](https://docs.rs/rerun/latest/rerun/components/struct.Range1D.html?speculative-link)

--- a/docs/content/reference/types/components/range2d.md
+++ b/docs/content/reference/types/components/range2d.md
@@ -9,7 +9,7 @@ An Axis-Aligned Bounding Box in 2D space.
 
 * range2d: [`Range2D`](../datatypes/range2d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Range2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Range2D.html?speculative-link)
  * 🐍 [Python API docs for `Range2D`](https://ref.rerun.io/docs/python/stable/common/components?speculative-link#rerun.components.Range2D)
  * 🦀 [Rust API docs for `Range2D`](https://docs.rs/rerun/latest/rerun/components/struct.Range2D.html?speculative-link)

--- a/docs/content/reference/types/components/resolution.md
+++ b/docs/content/reference/types/components/resolution.md
@@ -11,7 +11,7 @@ Typically in integer units, but for some use cases floating point may be used.
 
 * resolution: [`Vec2D`](../datatypes/vec2d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Resolution`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Resolution.html)
  * 🐍 [Python API docs for `Resolution`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Resolution)
  * 🦀 [Rust API docs for `Resolution`](https://docs.rs/rerun/latest/rerun/components/struct.Resolution.html)

--- a/docs/content/reference/types/components/rotation3d.md
+++ b/docs/content/reference/types/components/rotation3d.md
@@ -9,7 +9,7 @@ A 3D rotation, represented either by a quaternion or a rotation around axis.
 
 * repr: [`Rotation3D`](../datatypes/rotation3d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Rotation3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Rotation3D.html)
  * 🐍 [Python API docs for `Rotation3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Rotation3D)
  * 🦀 [Rust API docs for `Rotation3D`](https://docs.rs/rerun/latest/rerun/components/struct.Rotation3D.html)

--- a/docs/content/reference/types/components/scalar.md
+++ b/docs/content/reference/types/components/scalar.md
@@ -11,7 +11,7 @@ Used for time series plots.
 
 * value: `f64`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Scalar`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Scalar.html)
  * 🐍 [Python API docs for `Scalar`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Scalar)
  * 🦀 [Rust API docs for `Scalar`](https://docs.rs/rerun/latest/rerun/components/struct.Scalar.html)

--- a/docs/content/reference/types/components/scalar_scattering.md
+++ b/docs/content/reference/types/components/scalar_scattering.md
@@ -9,7 +9,7 @@ If true, a scalar will be shown as individual point in a scatter plot.
 
 * scattered: `bool`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `ScalarScattering`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ScalarScattering.html)
  * 🐍 [Python API docs for `ScalarScattering`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ScalarScattering)
  * 🦀 [Rust API docs for `ScalarScattering`](https://docs.rs/rerun/latest/rerun/components/struct.ScalarScattering.html)

--- a/docs/content/reference/types/components/stroke_width.md
+++ b/docs/content/reference/types/components/stroke_width.md
@@ -9,7 +9,7 @@ The width of a stroke specified in UI points.
 
 * width: `f32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `StrokeWidth`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1StrokeWidth.html)
  * 🐍 [Python API docs for `StrokeWidth`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.StrokeWidth)
  * 🦀 [Rust API docs for `StrokeWidth`](https://docs.rs/rerun/latest/rerun/components/struct.StrokeWidth.html)

--- a/docs/content/reference/types/components/tensor_data.md
+++ b/docs/content/reference/types/components/tensor_data.md
@@ -21,7 +21,7 @@ the shape has to be the shape of the decoded image.
 
 * data: [`TensorData`](../datatypes/tensor_data.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `TensorData`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TensorData.html)
  * 🐍 [Python API docs for `TensorData`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TensorData)
  * 🦀 [Rust API docs for `TensorData`](https://docs.rs/rerun/latest/rerun/components/struct.TensorData.html)

--- a/docs/content/reference/types/components/texcoord2d.md
+++ b/docs/content/reference/types/components/texcoord2d.md
@@ -24,7 +24,7 @@ which places the origin at the bottom-left.
 
 * uv: [`Vec2D`](../datatypes/vec2d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Texcoord2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Texcoord2D.html)
  * 🐍 [Python API docs for `Texcoord2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Texcoord2D)
  * 🦀 [Rust API docs for `Texcoord2D`](https://docs.rs/rerun/latest/rerun/components/struct.Texcoord2D.html)

--- a/docs/content/reference/types/components/text.md
+++ b/docs/content/reference/types/components/text.md
@@ -9,7 +9,7 @@ A string of text, e.g. for labels and text documents.
 
 * value: [`Utf8`](../datatypes/utf8.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Text`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Text.html)
  * 🐍 [Python API docs for `Text`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Text)
  * 🦀 [Rust API docs for `Text`](https://docs.rs/rerun/latest/rerun/components/struct.Text.html)

--- a/docs/content/reference/types/components/text_log_level.md
+++ b/docs/content/reference/types/components/text_log_level.md
@@ -17,7 +17,7 @@ Recommended to be one of:
 
 * value: [`Utf8`](../datatypes/utf8.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `TextLogLevel`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TextLogLevel.html)
  * 🐍 [Python API docs for `TextLogLevel`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TextLogLevel)
  * 🦀 [Rust API docs for `TextLogLevel`](https://docs.rs/rerun/latest/rerun/components/struct.TextLogLevel.html)

--- a/docs/content/reference/types/components/transform3d.md
+++ b/docs/content/reference/types/components/transform3d.md
@@ -9,7 +9,7 @@ An affine transform between two 3D spaces, represented in a given direction.
 
 * repr: [`Transform3D`](../datatypes/transform3d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Transform3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Transform3D.html)
  * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Transform3D)
  * 🦀 [Rust API docs for `Transform3D`](https://docs.rs/rerun/latest/rerun/components/struct.Transform3D.html)

--- a/docs/content/reference/types/components/triangle_indices.md
+++ b/docs/content/reference/types/components/triangle_indices.md
@@ -9,7 +9,7 @@ The three indices of a triangle mesh.
 
 * indices: [`UVec3D`](../datatypes/uvec3d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `TriangleIndices`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TriangleIndices.html?speculative-link)
  * 🐍 [Python API docs for `TriangleIndices`](https://ref.rerun.io/docs/python/stable/common/components?speculative-link#rerun.components.TriangleIndices)
  * 🦀 [Rust API docs for `TriangleIndices`](https://docs.rs/rerun/latest/rerun/components/struct.TriangleIndices.html?speculative-link)

--- a/docs/content/reference/types/components/vector2d.md
+++ b/docs/content/reference/types/components/vector2d.md
@@ -9,7 +9,7 @@ A vector in 2D space.
 
 * vector: [`Vec2D`](../datatypes/vec2d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Vector2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Vector2D.html)
  * 🐍 [Python API docs for `Vector2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Vector2D)
  * 🦀 [Rust API docs for `Vector2D`](https://docs.rs/rerun/latest/rerun/components/struct.Vector2D.html)

--- a/docs/content/reference/types/components/vector3d.md
+++ b/docs/content/reference/types/components/vector3d.md
@@ -9,7 +9,7 @@ A vector in 3D space.
 
 * vector: [`Vec3D`](../datatypes/vec3d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Vector3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Vector3D.html)
  * 🐍 [Python API docs for `Vector3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Vector3D)
  * 🦀 [Rust API docs for `Vector3D`](https://docs.rs/rerun/latest/rerun/components/struct.Vector3D.html)

--- a/docs/content/reference/types/components/view_coordinates.md
+++ b/docs/content/reference/types/components/view_coordinates.md
@@ -24,7 +24,7 @@ The following constants are used to represent the different directions:
 
 * coordinates: 3x `u8`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `ViewCoordinates`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ViewCoordinates.html)
  * 🐍 [Python API docs for `ViewCoordinates`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ViewCoordinates)
  * 🦀 [Rust API docs for `ViewCoordinates`](https://docs.rs/rerun/latest/rerun/components/struct.ViewCoordinates.html)

--- a/docs/content/reference/types/components/visualizer_overrides.md
+++ b/docs/content/reference/types/components/visualizer_overrides.md
@@ -9,7 +9,7 @@ The name of a visualizer.
 
 * value: list of `string`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `VisualizerOverrides`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1VisualizerOverrides.html)
  * 🐍 [Python API docs for `VisualizerOverrides`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.VisualizerOverrides)
  * 🦀 [Rust API docs for `VisualizerOverrides`](https://docs.rs/rerun/latest/rerun/components/struct.VisualizerOverrides.html)

--- a/docs/content/reference/types/datatypes/angle.md
+++ b/docs/content/reference/types/datatypes/angle.md
@@ -10,7 +10,7 @@ Angle in either radians or degrees.
 * Radians: `f32`
 * Degrees: `f32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Angle`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Angle.html)
  * 🐍 [Python API docs for `Angle`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Angle)
  * 🦀 [Rust API docs for `Angle`](https://docs.rs/rerun/latest/rerun/datatypes/enum.Angle.html)

--- a/docs/content/reference/types/datatypes/annotation_info.md
+++ b/docs/content/reference/types/datatypes/annotation_info.md
@@ -14,7 +14,7 @@ The id refers either to a class or key-point id
 * label: [`Utf8`](../datatypes/utf8.md)
 * color: [`Rgba32`](../datatypes/rgba32.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `AnnotationInfo`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1AnnotationInfo.html)
  * 🐍 [Python API docs for `AnnotationInfo`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.AnnotationInfo)
  * 🦀 [Rust API docs for `AnnotationInfo`](https://docs.rs/rerun/latest/rerun/datatypes/struct.AnnotationInfo.html)

--- a/docs/content/reference/types/datatypes/bool.md
+++ b/docs/content/reference/types/datatypes/bool.md
@@ -9,7 +9,7 @@ A single boolean.
 
 * value: `bool`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Bool`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Bool.html)
  * 🐍 [Python API docs for `Bool`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Bool)
  * 🦀 [Rust API docs for `Bool`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Bool.html)

--- a/docs/content/reference/types/datatypes/class_description.md
+++ b/docs/content/reference/types/datatypes/class_description.md
@@ -24,7 +24,7 @@ colored as described by the class's `AnnotationInfo`.
 * keypoint_annotations: list of [`AnnotationInfo`](../datatypes/annotation_info.md)
 * keypoint_connections: list of [`KeypointPair`](../datatypes/keypoint_pair.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `ClassDescription`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ClassDescription.html)
  * 🐍 [Python API docs for `ClassDescription`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ClassDescription)
  * 🦀 [Rust API docs for `ClassDescription`](https://docs.rs/rerun/latest/rerun/datatypes/struct.ClassDescription.html)

--- a/docs/content/reference/types/datatypes/class_description_map_elem.md
+++ b/docs/content/reference/types/datatypes/class_description_map_elem.md
@@ -12,7 +12,7 @@ This is internal to the `AnnotationContext` structure.
 * class_id: [`ClassId`](../datatypes/class_id.md)
 * class_description: [`ClassDescription`](../datatypes/class_description.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `ClassDescriptionMapElem`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ClassDescriptionMapElem.html)
  * 🐍 [Python API docs for `ClassDescriptionMapElem`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ClassDescriptionMapElem)
  * 🦀 [Rust API docs for `ClassDescriptionMapElem`](https://docs.rs/rerun/latest/rerun/datatypes/struct.ClassDescriptionMapElem.html)

--- a/docs/content/reference/types/datatypes/class_id.md
+++ b/docs/content/reference/types/datatypes/class_id.md
@@ -9,7 +9,7 @@ A 16-bit ID representing a type of semantic class.
 
 * id: `u16`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `ClassId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ClassId.html)
  * 🐍 [Python API docs for `ClassId`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ClassId)
  * 🦀 [Rust API docs for `ClassId`](https://docs.rs/rerun/latest/rerun/datatypes/struct.ClassId.html)

--- a/docs/content/reference/types/datatypes/entity_path.md
+++ b/docs/content/reference/types/datatypes/entity_path.md
@@ -9,7 +9,7 @@ A path to an entity in the `DataStore`.
 
 * path: `string`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `EntityPath`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1EntityPath.html)
  * 🐍 [Python API docs for `EntityPath`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.EntityPath)
  * 🦀 [Rust API docs for `EntityPath`](https://docs.rs/rerun/latest/rerun/datatypes/struct.EntityPath.html)

--- a/docs/content/reference/types/datatypes/float32.md
+++ b/docs/content/reference/types/datatypes/float32.md
@@ -9,7 +9,7 @@ A single-precision 32-bit IEEE 754 floating point number.
 
 * value: `f32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Float32`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Float32.html)
  * 🐍 [Python API docs for `Float32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Float32)
  * 🦀 [Rust API docs for `Float32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Float32.html)

--- a/docs/content/reference/types/datatypes/keypoint_id.md
+++ b/docs/content/reference/types/datatypes/keypoint_id.md
@@ -9,7 +9,7 @@ A 16-bit ID representing a type of semantic keypoint within a class.
 
 * id: `u16`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `KeypointId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1KeypointId.html)
  * 🐍 [Python API docs for `KeypointId`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.KeypointId)
  * 🦀 [Rust API docs for `KeypointId`](https://docs.rs/rerun/latest/rerun/datatypes/struct.KeypointId.html)

--- a/docs/content/reference/types/datatypes/keypoint_pair.md
+++ b/docs/content/reference/types/datatypes/keypoint_pair.md
@@ -10,7 +10,7 @@ A connection between two `Keypoints`.
 * keypoint0: [`KeypointId`](../datatypes/keypoint_id.md)
 * keypoint1: [`KeypointId`](../datatypes/keypoint_id.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `KeypointPair`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1KeypointPair.html)
  * 🐍 [Python API docs for `KeypointPair`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.KeypointPair)
  * 🦀 [Rust API docs for `KeypointPair`](https://docs.rs/rerun/latest/rerun/datatypes/struct.KeypointPair.html)

--- a/docs/content/reference/types/datatypes/mat3x3.md
+++ b/docs/content/reference/types/datatypes/mat3x3.md
@@ -18,7 +18,7 @@ row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
 
 * flat_columns: 9x `f32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Mat3x3`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Mat3x3.html)
  * 🐍 [Python API docs for `Mat3x3`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Mat3x3)
  * 🦀 [Rust API docs for `Mat3x3`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Mat3x3.html)

--- a/docs/content/reference/types/datatypes/mat4x4.md
+++ b/docs/content/reference/types/datatypes/mat4x4.md
@@ -19,7 +19,7 @@ row 3 | flat_columns[3]  flat_columns[7]  flat_columns[11] flat_columns[15]
 
 * flat_columns: 16x `f32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Mat4x4`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Mat4x4.html)
  * 🐍 [Python API docs for `Mat4x4`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Mat4x4)
  * 🦀 [Rust API docs for `Mat4x4`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Mat4x4.html)

--- a/docs/content/reference/types/datatypes/material.md
+++ b/docs/content/reference/types/datatypes/material.md
@@ -9,7 +9,7 @@ Material properties of a mesh.
 
 * albedo_factor: [`Rgba32`](../datatypes/rgba32.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Material`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Material.html)
  * 🐍 [Python API docs for `Material`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Material)
  * 🦀 [Rust API docs for `Material`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Material.html)

--- a/docs/content/reference/types/datatypes/quaternion.md
+++ b/docs/content/reference/types/datatypes/quaternion.md
@@ -12,7 +12,7 @@ datastore as provided, when used in the Viewer Quaternions will always be normal
 
 * xyzw: 4x `f32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Quaternion`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Quaternion.html)
  * 🐍 [Python API docs for `Quaternion`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Quaternion)
  * 🦀 [Rust API docs for `Quaternion`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Quaternion.html)

--- a/docs/content/reference/types/datatypes/range1d.md
+++ b/docs/content/reference/types/datatypes/range1d.md
@@ -9,7 +9,7 @@ A 1D range, specifying a lower and upper bound.
 
 * range: 2x `f64`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Range1D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Range1D.html?speculative-link)
  * 🐍 [Python API docs for `Range1D`](https://ref.rerun.io/docs/python/stable/common/datatypes?speculative-link#rerun.datatypes.Range1D)
  * 🦀 [Rust API docs for `Range1D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Range1D.html?speculative-link)

--- a/docs/content/reference/types/datatypes/range2d.md
+++ b/docs/content/reference/types/datatypes/range2d.md
@@ -10,7 +10,7 @@ An Axis-Aligned Bounding Box in 2D space, implemented as the minimum and maximum
 * x_range: [`Range1D`](../datatypes/range1d.md)
 * y_range: [`Range1D`](../datatypes/range1d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Range2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Range2D.html?speculative-link)
  * 🐍 [Python API docs for `Range2D`](https://ref.rerun.io/docs/python/stable/common/datatypes?speculative-link#rerun.datatypes.Range2D)
  * 🦀 [Rust API docs for `Range2D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Range2D.html?speculative-link)

--- a/docs/content/reference/types/datatypes/rgba32.md
+++ b/docs/content/reference/types/datatypes/rgba32.md
@@ -12,7 +12,7 @@ byte is `R` and the least significant byte is `A`.
 
 * rgba: `u32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Rgba32`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Rgba32.html)
  * 🐍 [Python API docs for `Rgba32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Rgba32)
  * 🦀 [Rust API docs for `Rgba32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Rgba32.html)

--- a/docs/content/reference/types/datatypes/rotation3d.md
+++ b/docs/content/reference/types/datatypes/rotation3d.md
@@ -10,7 +10,7 @@ A 3D rotation.
 * Quaternion: [`Quaternion`](../datatypes/quaternion.md)
 * AxisAngle: [`RotationAxisAngle`](../datatypes/rotation_axis_angle.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Rotation3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Rotation3D.html)
  * 🐍 [Python API docs for `Rotation3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Rotation3D)
  * 🦀 [Rust API docs for `Rotation3D`](https://docs.rs/rerun/latest/rerun/datatypes/enum.Rotation3D.html)

--- a/docs/content/reference/types/datatypes/rotation_axis_angle.md
+++ b/docs/content/reference/types/datatypes/rotation_axis_angle.md
@@ -10,7 +10,7 @@ title: "RotationAxisAngle"
 * axis: [`Vec3D`](../datatypes/vec3d.md)
 * angle: [`Angle`](../datatypes/angle.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1RotationAxisAngle.html)
  * 🐍 [Python API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.RotationAxisAngle)
  * 🦀 [Rust API docs for `RotationAxisAngle`](https://docs.rs/rerun/latest/rerun/datatypes/struct.RotationAxisAngle.html)

--- a/docs/content/reference/types/datatypes/scale3d.md
+++ b/docs/content/reference/types/datatypes/scale3d.md
@@ -10,7 +10,7 @@ title: "Scale3D"
 * ThreeD: [`Vec3D`](../datatypes/vec3d.md)
 * Uniform: `f32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Scale3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Scale3D.html)
  * 🐍 [Python API docs for `Scale3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Scale3D)
  * 🦀 [Rust API docs for `Scale3D`](https://docs.rs/rerun/latest/rerun/datatypes/enum.Scale3D.html)

--- a/docs/content/reference/types/datatypes/tensor_buffer.md
+++ b/docs/content/reference/types/datatypes/tensor_buffer.md
@@ -24,7 +24,7 @@ Tensor elements are stored in a contiguous buffer of a single type.
 * NV12: list of `u8`
 * YUY2: list of `u8`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `TensorBuffer`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorBuffer.html)
  * 🐍 [Python API docs for `TensorBuffer`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorBuffer)
  * 🦀 [Rust API docs for `TensorBuffer`](https://docs.rs/rerun/latest/rerun/datatypes/enum.TensorBuffer.html)

--- a/docs/content/reference/types/datatypes/tensor_data.md
+++ b/docs/content/reference/types/datatypes/tensor_data.md
@@ -22,7 +22,7 @@ the shape has to be the shape of the decoded image.
 * shape: list of [`TensorDimension`](../datatypes/tensor_dimension.md)
 * buffer: [`TensorBuffer`](../datatypes/tensor_buffer.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `TensorData`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorData.html)
  * 🐍 [Python API docs for `TensorData`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorData)
  * 🦀 [Rust API docs for `TensorData`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TensorData.html)

--- a/docs/content/reference/types/datatypes/tensor_dimension.md
+++ b/docs/content/reference/types/datatypes/tensor_dimension.md
@@ -10,7 +10,7 @@ A single dimension within a multi-dimensional tensor.
 * size: `u64`
 * name: `string`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `TensorDimension`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorDimension.html)
  * 🐍 [Python API docs for `TensorDimension`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorDimension)
  * 🦀 [Rust API docs for `TensorDimension`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TensorDimension.html)

--- a/docs/content/reference/types/datatypes/time_int.md
+++ b/docs/content/reference/types/datatypes/time_int.md
@@ -9,7 +9,7 @@ A 64-bit number describing either nanoseconds OR sequence numbers.
 
 * value: `i64`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `TimeInt`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TimeInt.html)
  * 🐍 [Python API docs for `TimeInt`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TimeInt)
  * 🦀 [Rust API docs for `TimeInt`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TimeInt.html)

--- a/docs/content/reference/types/datatypes/time_range.md
+++ b/docs/content/reference/types/datatypes/time_range.md
@@ -10,7 +10,7 @@ Visible time range bounds for a specific timeline.
 * start: [`TimeRangeBoundary`](../datatypes/time_range_boundary.md)
 * end: [`TimeRangeBoundary`](../datatypes/time_range_boundary.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `TimeRange`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TimeRange.html?speculative-link)
  * 🐍 [Python API docs for `TimeRange`](https://ref.rerun.io/docs/python/stable/common/datatypes?speculative-link#rerun.datatypes.TimeRange)
  * 🦀 [Rust API docs for `TimeRange`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TimeRange.html?speculative-link)

--- a/docs/content/reference/types/datatypes/time_range_boundary.md
+++ b/docs/content/reference/types/datatypes/time_range_boundary.md
@@ -11,7 +11,7 @@ Left or right boundary of a time range.
 * Absolute: [`TimeInt`](../datatypes/time_int.md)
 * Infinite
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `TimeRangeBoundary`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TimeRangeBoundary.html?speculative-link)
  * 🐍 [Python API docs for `TimeRangeBoundary`](https://ref.rerun.io/docs/python/stable/common/datatypes?speculative-link#rerun.datatypes.TimeRangeBoundary)
  * 🦀 [Rust API docs for `TimeRangeBoundary`](https://docs.rs/rerun/latest/rerun/datatypes/enum.TimeRangeBoundary.html?speculative-link)

--- a/docs/content/reference/types/datatypes/transform3d.md
+++ b/docs/content/reference/types/datatypes/transform3d.md
@@ -10,7 +10,7 @@ Representation of a 3D affine transform.
 * TranslationAndMat3x3: [`TranslationAndMat3x3`](../datatypes/translation_and_mat3x3.md)
 * TranslationRotationScale: [`TranslationRotationScale3D`](../datatypes/translation_rotation_scale3d.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Transform3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Transform3D.html)
  * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Transform3D)
  * 🦀 [Rust API docs for `Transform3D`](https://docs.rs/rerun/latest/rerun/datatypes/enum.Transform3D.html)

--- a/docs/content/reference/types/datatypes/translation_and_mat3x3.md
+++ b/docs/content/reference/types/datatypes/translation_and_mat3x3.md
@@ -13,7 +13,7 @@ First applies the matrix, then the translation.
 * mat3x3: [`Mat3x3`](../datatypes/mat3x3.md)
 * from_parent: `bool`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `TranslationAndMat3x3`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TranslationAndMat3x3.html)
  * 🐍 [Python API docs for `TranslationAndMat3x3`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TranslationAndMat3x3)
  * 🦀 [Rust API docs for `TranslationAndMat3x3`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TranslationAndMat3x3.html)

--- a/docs/content/reference/types/datatypes/translation_rotation_scale3d.md
+++ b/docs/content/reference/types/datatypes/translation_rotation_scale3d.md
@@ -12,7 +12,7 @@ Representation of an affine transform via separate translation, rotation & scale
 * scale: [`Scale3D`](../datatypes/scale3d.md)
 * from_parent: `bool`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `TranslationRotationScale3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TranslationRotationScale3D.html)
  * 🐍 [Python API docs for `TranslationRotationScale3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TranslationRotationScale3D)
  * 🦀 [Rust API docs for `TranslationRotationScale3D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TranslationRotationScale3D.html)

--- a/docs/content/reference/types/datatypes/uint32.md
+++ b/docs/content/reference/types/datatypes/uint32.md
@@ -9,7 +9,7 @@ A 32bit unsigned integer.
 
 * value: `u32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `UInt32`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UInt32.html)
  * 🐍 [Python API docs for `UInt32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UInt32)
  * 🦀 [Rust API docs for `UInt32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt32.html)

--- a/docs/content/reference/types/datatypes/uint64.md
+++ b/docs/content/reference/types/datatypes/uint64.md
@@ -9,7 +9,7 @@ A 64bit unsigned integer.
 
 * value: `u64`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `UInt64`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UInt64.html)
  * 🐍 [Python API docs for `UInt64`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UInt64)
  * 🦀 [Rust API docs for `UInt64`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt64.html)

--- a/docs/content/reference/types/datatypes/utf8.md
+++ b/docs/content/reference/types/datatypes/utf8.md
@@ -9,7 +9,7 @@ A string of text, encoded as UTF-8.
 
 * value: `string`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Utf8`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Utf8.html)
  * 🐍 [Python API docs for `Utf8`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Utf8)
  * 🦀 [Rust API docs for `Utf8`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Utf8.html)

--- a/docs/content/reference/types/datatypes/uuid.md
+++ b/docs/content/reference/types/datatypes/uuid.md
@@ -9,7 +9,7 @@ A 16-byte UUID.
 
 * bytes: 16x `u8`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Uuid`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Uuid.html)
  * 🐍 [Python API docs for `Uuid`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Uuid)
  * 🦀 [Rust API docs for `Uuid`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Uuid.html)

--- a/docs/content/reference/types/datatypes/uvec2d.md
+++ b/docs/content/reference/types/datatypes/uvec2d.md
@@ -9,7 +9,7 @@ A uint32 vector in 2D space.
 
 * xy: 2x `u32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `UVec2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UVec2D.html)
  * 🐍 [Python API docs for `UVec2D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UVec2D)
  * 🦀 [Rust API docs for `UVec2D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UVec2D.html)

--- a/docs/content/reference/types/datatypes/uvec3d.md
+++ b/docs/content/reference/types/datatypes/uvec3d.md
@@ -9,7 +9,7 @@ A uint32 vector in 3D space.
 
 * xyz: 3x `u32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `UVec3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UVec3D.html)
  * 🐍 [Python API docs for `UVec3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UVec3D)
  * 🦀 [Rust API docs for `UVec3D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UVec3D.html)

--- a/docs/content/reference/types/datatypes/uvec4d.md
+++ b/docs/content/reference/types/datatypes/uvec4d.md
@@ -9,7 +9,7 @@ A uint vector in 4D space.
 
 * xyzw: 4x `u32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `UVec4D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UVec4D.html)
  * 🐍 [Python API docs for `UVec4D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UVec4D)
  * 🦀 [Rust API docs for `UVec4D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UVec4D.html)

--- a/docs/content/reference/types/datatypes/vec2d.md
+++ b/docs/content/reference/types/datatypes/vec2d.md
@@ -9,7 +9,7 @@ A vector in 2D space.
 
 * xy: 2x `f32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Vec2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Vec2D.html)
  * 🐍 [Python API docs for `Vec2D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Vec2D)
  * 🦀 [Rust API docs for `Vec2D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Vec2D.html)

--- a/docs/content/reference/types/datatypes/vec3d.md
+++ b/docs/content/reference/types/datatypes/vec3d.md
@@ -9,7 +9,7 @@ A vector in 3D space.
 
 * xyz: 3x `f32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Vec3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Vec3D.html)
  * 🐍 [Python API docs for `Vec3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Vec3D)
  * 🦀 [Rust API docs for `Vec3D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Vec3D.html)

--- a/docs/content/reference/types/datatypes/vec4d.md
+++ b/docs/content/reference/types/datatypes/vec4d.md
@@ -9,7 +9,7 @@ A vector in 4D space.
 
 * xyzw: 4x `f32`
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `Vec4D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Vec4D.html)
  * 🐍 [Python API docs for `Vec4D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Vec4D)
  * 🦀 [Rust API docs for `Vec4D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Vec4D.html)

--- a/docs/content/reference/types/datatypes/visible_time_range.md
+++ b/docs/content/reference/types/datatypes/visible_time_range.md
@@ -10,7 +10,7 @@ Visible time range bounds for a specific timeline.
 * timeline: [`Utf8`](../datatypes/utf8.md)
 * range: [`TimeRange`](../datatypes/time_range.md)
 
-## Api reference links
+## API reference links
  * 🌊 [C++ API docs for `VisibleTimeRange`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1VisibleTimeRange.html?speculative-link)
  * 🐍 [Python API docs for `VisibleTimeRange`](https://ref.rerun.io/docs/python/stable/common/datatypes?speculative-link#rerun.datatypes.VisibleTimeRange)
  * 🦀 [Rust API docs for `VisibleTimeRange`](https://docs.rs/rerun/latest/rerun/datatypes/struct.VisibleTimeRange.html?speculative-link)

--- a/docs/content/reference/types/views/bar_chart_view.md
+++ b/docs/content/reference/types/views/bar_chart_view.md
@@ -6,7 +6,7 @@ title: "BarChartView"
 A bar chart view.
 
 
-## Api reference links
+## API reference links
  * 🐍 [Python API docs for `BarChartView`](https://ref.rerun.io/docs/python/stable/common/blueprint_views?speculative-link#rerun.blueprint.views.BarChartView)
 
 ## Example

--- a/docs/content/reference/types/views/spatial2d_view.md
+++ b/docs/content/reference/types/views/spatial2d_view.md
@@ -23,7 +23,7 @@ Configures which range on each timeline is shown by this view (unless specified 
 If not specified, the default is to show the latest state of each component.
 If a timeline is specified more than once, the first entry will be used.
 
-## Api reference links
+## API reference links
  * 🐍 [Python API docs for `Spatial2DView`](https://ref.rerun.io/docs/python/stable/common/blueprint_views?speculative-link#rerun.blueprint.views.Spatial2DView)
 
 ## Example

--- a/docs/content/reference/types/views/spatial3d_view.md
+++ b/docs/content/reference/types/views/spatial3d_view.md
@@ -18,7 +18,7 @@ Configures which range on each timeline is shown by this view (unless specified 
 If not specified, the default is to show the latest state of each component.
 If a timeline is specified more than once, the first entry will be used.
 
-## Api reference links
+## API reference links
  * 🐍 [Python API docs for `Spatial3DView`](https://ref.rerun.io/docs/python/stable/common/blueprint_views?speculative-link#rerun.blueprint.views.Spatial3DView)
 
 ## Example

--- a/docs/content/reference/types/views/tensor_view.md
+++ b/docs/content/reference/types/views/tensor_view.md
@@ -6,7 +6,7 @@ title: "TensorView"
 A tensor view.
 
 
-## Api reference links
+## API reference links
  * 🐍 [Python API docs for `TensorView`](https://ref.rerun.io/docs/python/stable/common/blueprint_views?speculative-link#rerun.blueprint.views.TensorView)
 
 ## Example

--- a/docs/content/reference/types/views/text_document_view.md
+++ b/docs/content/reference/types/views/text_document_view.md
@@ -6,7 +6,7 @@ title: "TextDocumentView"
 A text document view.
 
 
-## Api reference links
+## API reference links
  * 🐍 [Python API docs for `TextDocumentView`](https://ref.rerun.io/docs/python/stable/common/blueprint_views?speculative-link#rerun.blueprint.views.TextDocumentView)
 
 ## Example

--- a/docs/content/reference/types/views/text_log_view.md
+++ b/docs/content/reference/types/views/text_log_view.md
@@ -6,7 +6,7 @@ title: "TextLogView"
 A text log view.
 
 
-## Api reference links
+## API reference links
  * 🐍 [Python API docs for `TextLogView`](https://ref.rerun.io/docs/python/stable/common/blueprint_views?speculative-link#rerun.blueprint.views.TextLogView)
 
 ## Example

--- a/docs/content/reference/types/views/time_series_view.md
+++ b/docs/content/reference/types/views/time_series_view.md
@@ -23,7 +23,7 @@ Configures which range on each timeline is shown by this view (unless specified 
 If not specified, the default is to show the entire timeline.
 If a timeline is specified more than once, the first entry will be used.
 
-## Api reference links
+## API reference links
  * 🐍 [Python API docs for `TimeSeriesView`](https://ref.rerun.io/docs/python/stable/common/blueprint_views?speculative-link#rerun.blueprint.views.TimeSeriesView)
 
 ## Example


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6328](https://togithub.com/rerun-io/rerun/pull/6328).



The original branch is upstream/andreas/fix-lint-issues-on-doc-gen