### PR TITLE
Cleanup usage of unsafe() in re_data_store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -428,6 +428,7 @@ verbose_file_reads = "warn"
 wildcard_dependencies = "warn"
 wildcard_imports = "warn"
 zero_sized_map_values = "warn"
+unwrap_used = "warn"
 # Disabled waiting on https://github.com/rust-lang/rust-clippy/issues/9602
 #self_named_module_files = "warn"
 
@@ -439,12 +440,6 @@ iter_over_hash_type = "allow"
 let_underscore_untyped = "allow"
 missing_assert_message = "allow"
 missing_errors_doc = "allow"
-
-# TODO(#3408): Forbid `.unwrap()`
-# This would be nice to enable, but we have way too many unwraps right now 😭
-# Enabling this lint in 2023-04-27 yielded 556 hits.
-# Enabling this lint in 2023-09-23 yielded 352 hits
-unwrap_used = "warn"
 
 [patch.crates-io]
 # Try to avoid patching crates! It prevents us from publishing the crates on crates.io.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -423,12 +423,12 @@ unnested_or_patterns = "warn"
 unused_peekable = "warn"
 unused_rounding = "warn"
 unused_self = "warn"
+unwrap_used = "warn"
 useless_transmute = "warn"
 verbose_file_reads = "warn"
 wildcard_dependencies = "warn"
 wildcard_imports = "warn"
 zero_sized_map_values = "warn"
-unwrap_used = "warn"
 # Disabled waiting on https://github.com/rust-lang/rust-clippy/issues/9602
 #self_named_module_files = "warn"
 

--- a/crates/re_data_store/src/arrow_util.rs
+++ b/crates/re_data_store/src/arrow_util.rs
@@ -19,10 +19,10 @@ impl ArrayExt for dyn Array {
     fn get_child_length(&self, child_nr: usize) -> usize {
         self.as_any()
             .downcast_ref::<ListArray<i32>>()
-            .unwrap()
+            .expect("not a ListArray<i32>")
             .offsets()
             .lengths()
             .nth(child_nr)
-            .unwrap()
+            .unwrap_or_else(|| panic!("no child at index {child_nr}"))
     }
 }

--- a/crates/re_data_store/src/lib.rs
+++ b/crates/re_data_store/src/lib.rs
@@ -14,9 +14,6 @@
 #![doc = document_features::document_features!()]
 //!
 
-// TODO(#3408): remove unwrap()
-#![allow(clippy::unwrap_used)]
-
 mod arrow_util;
 mod store;
 mod store_arrow;
@@ -34,7 +31,6 @@ mod store_write;
 #[doc(hidden)]
 pub mod test_util;
 
-pub use self::arrow_util::ArrayExt;
 pub use self::store::{DataStore, DataStoreConfig, StoreGeneration};
 pub use self::store_event::{StoreDiff, StoreDiffKind, StoreEvent};
 pub use self::store_gc::{GarbageCollectionOptions, GarbageCollectionTarget};

--- a/crates/re_data_store/src/store_gc.rs
+++ b/crates/re_data_store/src/store_gc.rs
@@ -163,6 +163,7 @@ impl DataStore {
         }
 
         #[cfg(debug_assertions)]
+        #[allow(clippy::unwrap_used)]
         self.sanity_check().unwrap();
 
         // NOTE: only temporal data and row metadata get purged!

--- a/crates/re_data_store/src/store_read.rs
+++ b/crates/re_data_store/src/store_read.rs
@@ -454,7 +454,9 @@ impl IndexedTable {
     pub fn find_bucket(&self, time: TimeInt) -> (TimeInt, &IndexedBucket) {
         // This cannot fail, `iter_bucket` is guaranteed to always yield at least one bucket,
         // since indexed tables always spawn with a default bucket that covers [-∞;+∞].
-        self.range_buckets_rev(..=time).next().unwrap()
+        self.range_buckets_rev(..=time)
+            .next()
+            .expect("this cannot fail")
     }
 
     /// Returns the indexed bucket whose time range covers the given `time`.
@@ -466,7 +468,9 @@ impl IndexedTable {
     pub fn find_bucket_mut(&mut self, time: TimeInt) -> (TimeInt, &mut IndexedBucket) {
         // This cannot fail, `iter_bucket_mut` is guaranteed to always yield at least one bucket,
         // since indexed tables always spawn with a default bucket that covers [-∞;+∞].
-        self.range_bucket_rev_mut(..=time).next().unwrap()
+        self.range_bucket_rev_mut(..=time)
+            .next()
+            .expect("this cannot fail")
     }
 
     /// Returns an iterator that is guaranteed to yield at least one bucket, which is the bucket

--- a/crates/re_data_store/src/store_read.rs
+++ b/crates/re_data_store/src/store_read.rs
@@ -454,9 +454,8 @@ impl IndexedTable {
     pub fn find_bucket(&self, time: TimeInt) -> (TimeInt, &IndexedBucket) {
         // This cannot fail, `iter_bucket` is guaranteed to always yield at least one bucket,
         // since indexed tables always spawn with a default bucket that covers [-∞;+∞].
-        self.range_buckets_rev(..=time)
-            .next()
-            .expect("this cannot fail")
+        #[allow(clippy::unwrap_used)]
+        self.range_buckets_rev(..=time).next().unwrap()
     }
 
     /// Returns the indexed bucket whose time range covers the given `time`.
@@ -468,9 +467,8 @@ impl IndexedTable {
     pub fn find_bucket_mut(&mut self, time: TimeInt) -> (TimeInt, &mut IndexedBucket) {
         // This cannot fail, `iter_bucket_mut` is guaranteed to always yield at least one bucket,
         // since indexed tables always spawn with a default bucket that covers [-∞;+∞].
-        self.range_bucket_rev_mut(..=time)
-            .next()
-            .expect("this cannot fail")
+        #[allow(clippy::unwrap_used)]
+        self.range_bucket_rev_mut(..=time).next().unwrap()
     }
 
     /// Returns an iterator that is guaranteed to yield at least one bucket, which is the bucket

--- a/crates/re_data_store/src/store_write.rs
+++ b/crates/re_data_store/src/store_write.rs
@@ -401,6 +401,7 @@ impl IndexedBucket {
         *size_bytes += size_bytes_added;
 
         #[cfg(debug_assertions)]
+        #[allow(clippy::unwrap_used)]
         {
             drop(inner);
             self.sanity_check().unwrap();
@@ -534,6 +535,7 @@ impl IndexedBucket {
 
         // sanity checks
         #[cfg(debug_assertions)]
+        #[allow(clippy::unwrap_used)]
         {
             drop(inner1); // sanity checking will grab the lock!
             self.sanity_check().unwrap();

--- a/crates/re_data_store/src/test_util.rs
+++ b/crates/re_data_store/src/test_util.rs
@@ -66,12 +66,14 @@ pub fn sanity_unwrap(store: &DataStore) {
     if let err @ Err(_) = store.sanity_check() {
         store.sort_indices_if_needed();
         eprintln!("{store}");
+        #[allow(clippy::unwrap_used)] // we want to panic here
         err.unwrap();
     }
 }
 
 // We very often re-use RowIds when generating test data.
 pub fn insert_table_with_retries(store: &mut DataStore, table: &DataTable) {
+    #[allow(clippy::unwrap_used)] // ok for tests
     for row in table.to_rows() {
         let mut row = row.unwrap();
         loop {


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6334](https://togithub.com/rerun-io/rerun/pull/6334).



The original branch is fork-6334-Artxiom/6330-refactor-unwrap-re_data_store