### PR TITLE
Move sort out of inner loop to fix perf regression on updating range …

### DIFF
--- a/crates/re_query/src/range/query.rs
+++ b/crates/re_query/src/range/query.rs
@@ -242,6 +242,9 @@ impl RangeCache {
                 per_data_time
                     .promises_front
                     .push(((data_time, row_id), Promise::new(cell)));
+            }
+            {
+                re_tracing::profile_scope!("sort front");
                 per_data_time
                     .promises_front
                     .sort_by_key(|(index, _)| *index);
@@ -267,6 +270,9 @@ impl RangeCache {
                 per_data_time
                     .promises_back
                     .push(((data_time, row_id), Promise::new(cell)));
+            }
+            {
+                re_tracing::profile_scope!("sort back");
                 per_data_time.promises_back.sort_by_key(|(index, _)| *index);
             }
         }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6338](https://togithub.com/rerun-io/rerun/pull/6338).



The original branch is upstream/jleibs/cache_perf_sort