### PR TITLE
Fix typo in VisualBounds2DExt causing it to throw

### DIFF
--- a/crates/re_dev_tools/src/build_examples/snippets.rs
+++ b/crates/re_dev_tools/src/build_examples/snippets.rs
@@ -133,7 +133,7 @@ fn collect_snippets_recursively(
             .cloned()
             .unwrap_or_default()
             .into_iter()
-            .map(|value| value.replace("$config_dir", dir.as_str()))
+            .map(|value| value.replace("$config_dir", snippet_root_path.parent().unwrap().as_str()))
             .collect();
         snippets.push(Snippet {
             extra_args,

--- a/docs/snippets/compare_snippet_output.py
+++ b/docs/snippets/compare_snippet_output.py
@@ -45,8 +45,7 @@ class Example:
         for key in [self.subdir, self.subdir + "/" + self.name]:
             if key in EXTRA_ARGS:
                 return [
-                    arg.replace("$config_dir", str(Path(__file__).parent.parent.absolute()))
-                    for arg in EXTRA_ARGS.get(key, [])
+                    arg.replace("$config_dir", str(Path(__file__).parent.absolute())) for arg in EXTRA_ARGS.get(key, [])
                 ]
         return []
 

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -125,5 +125,5 @@ quick_start = [ # These examples don't have exactly the same implementation.
 
 # `$config_dir` will be replaced with the absolute path of `docs/snippets`.
 [extra_args]
-"archetypes/asset3d_simple" = ["$config_dir/assets/cube.glb"]
-"archetypes/asset3d_out_of_tree" = ["$config_dir/assets/cube.glb"]
+"archetypes/asset3d_simple" = ["$config_dir/../assets/cube.glb"]
+"archetypes/asset3d_out_of_tree" = ["$config_dir/../assets/cube.glb"]

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visual_bounds2d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visual_bounds2d_ext.py
@@ -29,6 +29,6 @@ class VisualBounds2DExt:
         """
 
         with catch_and_log_exceptions(context=self.__class__.__name__):
-            self.__attrs_init__(range2d=blueprint_components.VisualBounds2D(x_range=x_range, y_range=y_range))
+            self.__attrs_init__(range=blueprint_components.VisualBounds2D(x_range=x_range, y_range=y_range))
             return
         self.__attrs_clear__()


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6342](https://togithub.com/rerun-io/rerun/pull/6342).



The original branch is upstream/andreas/fix-visualbounds2dext