### PR TITLE
Quiet the 'not a mono-batch' log spam when selecting keypoint with a batch class-id

### DIFF
--- a/crates/re_data_ui/src/annotation_context.rs
+++ b/crates/re_data_ui/src/annotation_context.rs
@@ -94,9 +94,13 @@ fn annotation_info(
     keypoint_id: KeypointId,
 ) -> Option<AnnotationInfo> {
     // TODO(#5607): what should happen if the promise is still pending?
+
+    // TODO(#6358): this needs to use the index of the keypoint to look up the correct
+    // class_id. For now we use `latest_at_component_quiet` to avoid the warning spam.
     let class_id = ctx
         .recording()
-        .latest_at_component::<re_types::components::ClassId>(entity_path, query)?;
+        .latest_at_component_quiet::<re_types::components::ClassId>(entity_path, query)?;
+
     let annotations = crate::annotations(ctx, query, entity_path);
     let class = annotations.resolved_class_description(Some(class_id.value));
     class.keypoint_map?.get(&keypoint_id).cloned()


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6359](https://togithub.com/rerun-io/rerun/pull/6359).



The original branch is upstream/jleibs/quiet_keypoint_log_spam