### PR TITLE
Fix width/height/channel extraction logic

### DIFF
--- a/crates/re_types/src/datatypes/tensor_data_ext.rs
+++ b/crates/re_types/src/datatypes/tensor_data_ext.rs
@@ -875,11 +875,18 @@ fn test_image_height_width_channels() {
         // h=1, w=1, RGB:
         (vec![1, 1, 3], Some([1, 1, 3])),
         (vec![1, 1, 1, 3], Some([1, 1, 3])),
-        (vec![1, 1, 3, 1], Some([1, 1, 3])),
         //
         // h=1, w=3, Mono:
         (vec![1, 3, 1], Some([1, 3, 1])),
         (vec![1, 3, 1, 1], Some([1, 3, 1])),
+        //
+        // Ambiguous cases.
+        //
+        // This could validly be RGB or Mono. This is here to show how the current implementation
+        // behaves, not to suggest that it is a commitment to preserving this behavior going forward.
+        // If you need to change this test, it's ok but we should still communicate the subtle change
+        // in behavior.
+        (vec![1, 1, 3, 1], Some([1, 1, 3])),
     ];
 
     for (shape, expected_hwc) in test_cases {

--- a/crates/re_types/src/datatypes/tensor_data_ext.rs
+++ b/crates/re_types/src/datatypes/tensor_data_ext.rs
@@ -878,15 +878,15 @@ fn test_image_height_width_channels() {
         //
         // h=1, w=3, Mono:
         (vec![1, 3, 1], Some([1, 3, 1])),
-        (vec![1, 3, 1, 1], Some([1, 3, 1])),
         //
         // Ambiguous cases.
         //
-        // This could validly be RGB or Mono. This is here to show how the current implementation
-        // behaves, not to suggest that it is a commitment to preserving this behavior going forward.
+        // These are here to show how the current implementation behaves, not to suggest that it is a
+        // commitment to preserving this behavior going forward.
         // If you need to change this test, it's ok but we should still communicate the subtle change
         // in behavior.
-        (vec![1, 1, 3, 1], Some([1, 1, 3])),
+        (vec![1, 1, 3, 1], Some([1, 1, 3])), // Could be [1, 3, 1]
+        (vec![1, 3, 1, 1], Some([1, 3, 1])), // Could be [3, 1, 1]
     ];
 
     for (shape, expected_hwc) in test_cases {


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6360](https://togithub.com/rerun-io/rerun/pull/6360).



The original branch is upstream/emilk/fix-tensor-hwc