### PR TITLE
Don't log warnings when unknown clients connect over TCP

### DIFF
--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -983,7 +983,6 @@ impl App {
                             format!("Data source {} has left unexpectedly: {err}", msg.source);
 
                         #[cfg(not(target_arch = "wasm32"))]
-                        #[cfg(feature = "server")]
                         if err
                             .downcast_ref::<re_sdk_comms::ConnectionError>()
                             .is_some_and(|e| {


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6368](https://togithub.com/rerun-io/rerun/pull/6368).



The original branch is upstream/emilk/silence-warnings-on-tcp