### PR TITLE
Revert making web_viewer a default feature of rerun_py

### DIFF
--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -15,7 +15,7 @@ name = "rerun_bindings" # name of the .so library that the Python module will im
 
 
 [features]
-default = ["extension-module", "web_viewer"]
+default = ["extension-module"]
 
 ## The features we turn on when building the `rerun-sdk` PyPi package
 ## for <https://pypi.org/project/rerun-sdk/>.


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6370](https://togithub.com/rerun-io/rerun/pull/6370).



The original branch is upstream/andreas/undo-webviewer-default-python