### PR TITLE
Drop rerun_cpp_sdk-{tag}-multiplatform.zip in favor of rerun_cpp_sdk.zip

### DIFF
--- a/scripts/ci/sync_release_assets.py
+++ b/scripts/ci/sync_release_assets.py
@@ -129,7 +129,12 @@ def fetch_binary_assets(
             if blob is not None and blob.name is not None:
                 name = blob.name.split("/")[-1]
                 print(f"Found Rerun cross-platform bundle: {name}")
-                assets[f"rerun_cpp_sdk-{tag}-multiplatform.zip"] = blob
+                # ATTENTION: Renaming this file has tremendous ripple effects:
+                # Not only is this the convenient short name we use examples,
+                # we also rely on https://github.com/rerun-io/rerun/releases/latest/download/rerun_cpp_sdk.zip
+                # to always give you the latest stable version of the Rerun SDK.
+                # -> The name should *not* contain the version number.
+                assets[f"rerun_cpp_sdk.zip"] = blob
             else:
                 all_found = False
                 print("Rerun cross-platform bundle not found")


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6373](https://togithub.com/rerun-io/rerun/pull/6373).



The original branch is upstream/andreas/cppsdkzipartifactfix