### PR TITLE
Fix re_sdk_comms isolated compilation

### DIFF
--- a/crates/re_sdk_comms/src/lib.rs
+++ b/crates/re_sdk_comms/src/lib.rs
@@ -37,6 +37,7 @@ pub enum ConnectionError {
     SendError(#[from] std::io::Error),
 
     #[error(transparent)]
+    #[cfg(feature = "server")]
     DecodeError(#[from] re_log_encoding::decoder::DecodeError),
 
     #[error("The receiving end of the channel was closed")]


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6391](https://togithub.com/rerun-io/rerun/pull/6391).



The original branch is upstream/andreas/fix-re_sdk_commms-compilation