### PR TITLE
Update ewebsock to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "ewebsock"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6177769715c6ec5a324acee995183b22721ea23c58e49af14a828eadec85d120"
+checksum = "1bbed098b2bf9abcfe50eeaa01ae77a2a1da931bdcd83d23fcd7b8f941cd52c9"
 dependencies = [
  "document-features",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ document-features = "0.2.8"
 ehttp = "0.5.0"
 enumset = "1.0.12"
 env_logger = { version = "0.10", default-features = false }
-ewebsock = "0.5.0"
+ewebsock = "0.6.0"
 fixed = { version = "1.17", default-features = false }
 flatbuffers = "23.0"
 futures-channel = "0.3"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6394](https://togithub.com/rerun-io/rerun/pull/6394).



The original branch is upstream/emilk/update-ewebsock