### PR TITLE
Don't use static timepoint for the welcome screen panel state

### DIFF
--- a/crates/re_viewer/src/app_blueprint.rs
+++ b/crates/re_viewer/src/app_blueprint.rs
@@ -1,6 +1,6 @@
 use re_data_store::LatestAtQuery;
 use re_entity_db::EntityDb;
-use re_log_types::{DataRow, EntityPath, RowId, TimePoint};
+use re_log_types::{DataRow, EntityPath, RowId};
 use re_types::blueprint::components::PanelExpanded;
 use re_viewer_context::{CommandSender, StoreContext, SystemCommand, SystemCommandSender};
 
@@ -88,8 +88,8 @@ pub fn setup_welcome_screen_blueprint(welcome_screen_blueprint: &mut EntityDb) {
         (TIME_PANEL_PATH, false),
     ] {
         let entity_path = EntityPath::from(panel_name);
-        // TODO(jleibs): Seq instead of timeless?
-        let timepoint = TimePoint::default();
+
+        let timepoint = re_viewer_context::blueprint_timepoint_for_writes(welcome_screen_blueprint);
 
         let component = PanelExpanded(is_expanded.into());
 

--- a/crates/re_viewer_context/src/blueprint_helpers.rs
+++ b/crates/re_viewer_context/src/blueprint_helpers.rs
@@ -8,21 +8,25 @@ pub fn blueprint_timeline() -> Timeline {
     Timeline::new_sequence("blueprint")
 }
 
+/// The timepoint to use when writing an update to the blueprint.
+pub fn blueprint_timepoint_for_writes(blueprint: &re_entity_db::EntityDb) -> TimePoint {
+    let timeline = blueprint_timeline();
+
+    let max_time = blueprint
+        .times_per_timeline()
+        .get(&timeline)
+        .and_then(|times| times.last_key_value())
+        .map_or(0, |(time, _)| time.as_i64())
+        .saturating_add(1);
+
+    TimePoint::from([(timeline, TimeInt::new_temporal(max_time))])
+}
+
 impl StoreContext<'_> {
     /// The timepoint to use when writing an update to the blueprint.
     #[inline]
     pub fn blueprint_timepoint_for_writes(&self) -> TimePoint {
-        let timeline = blueprint_timeline();
-
-        let max_time = self
-            .blueprint
-            .times_per_timeline()
-            .get(&timeline)
-            .and_then(|times| times.last_key_value())
-            .map_or(0, |(time, _)| time.as_i64())
-            .saturating_add(1);
-
-        TimePoint::from([(timeline, TimeInt::new_temporal(max_time))])
+        blueprint_timepoint_for_writes(self.blueprint)
     }
 }
 

--- a/crates/re_viewer_context/src/lib.rs
+++ b/crates/re_viewer_context/src/lib.rs
@@ -32,7 +32,7 @@ pub use annotations::{
     AnnotationMap, Annotations, ResolvedAnnotationInfo, ResolvedAnnotationInfos,
 };
 pub use app_options::AppOptions;
-pub use blueprint_helpers::blueprint_timeline;
+pub use blueprint_helpers::{blueprint_timeline, blueprint_timepoint_for_writes};
 pub use blueprint_id::{BlueprintId, BlueprintIdRegistry, ContainerId, SpaceViewId};
 pub use caches::{Cache, Caches};
 pub use collapsed_id::{CollapseItem, CollapseScope, CollapsedId};


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6406](https://togithub.com/rerun-io/rerun/pull/6406).



The original branch is upstream/jleibs/blueprint_panels