### PR TITLE
Fix broken example source links in Viewer example list

### DIFF
--- a/crates/re_dev_tools/src/build_examples/example.rs
+++ b/crates/re_dev_tools/src/build_examples/example.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 use anyhow::Context;
 
 pub struct Example {
+    /// Name of the folder it's stored in.
     pub name: String,
     pub title: String,
     pub dir: PathBuf,

--- a/crates/re_dev_tools/src/build_examples/manifest.rs
+++ b/crates/re_dev_tools/src/build_examples/manifest.rs
@@ -85,9 +85,8 @@ impl ManifestEntry {
                 height: example.thumbnail_dimensions[1],
             },
             source_url: format!(
-                "{base_source_url}/examples/{}/{name}/{}",
+                "{base_source_url}/examples/{}/{name}",
                 example.language.examples_dir().to_string_lossy(),
-                example.script_path.to_string_lossy(),
             ),
             name,
         }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6451](https://togithub.com/rerun-io/rerun/pull/6451).



The original branch is upstream/andreas/fix-example-manifest-source-url