### PR TITLE
Remove option to enable/disable depth projection from ui

### DIFF
--- a/crates/re_entity_db/src/entity_properties.rs
+++ b/crates/re_entity_db/src/entity_properties.rs
@@ -97,13 +97,6 @@ pub struct EntityProperties {
     // TODO(#5067): Test property used so we don't have to continuously adjust existing tests while we're dismantling `EntityProperties`.
     pub test_property: bool,
 
-    /// Should the depth texture be backprojected into a point cloud?
-    ///
-    /// Only applies to tensors with meaning=depth that are affected by a pinhole transform.
-    ///
-    /// The default for 3D views is `true`, but for 2D views it is `false`.
-    pub backproject_depth: EditableAutoValue<bool>, // TODO(andreas): should be a component on the DepthImage archetype.
-
     /// How many depth units per world-space unit. e.g. 1000 for millimeters.
     ///
     /// This corresponds to `re_components::Tensor::meter`.
@@ -121,7 +114,6 @@ impl Default for EntityProperties {
     fn default() -> Self {
         Self {
             test_property: true,
-            backproject_depth: EditableAutoValue::Auto(true),
             depth_from_world_scale: EditableAutoValue::Auto(1.0),
             backproject_radius_scale: EditableAutoValue::Auto(1.0),
             time_series_aggregator: EditableAutoValue::Auto(TimeSeriesAggregator::default()),
@@ -136,7 +128,6 @@ impl EntityProperties {
         Self {
             test_property: self.test_property && child.test_property,
 
-            backproject_depth: self.backproject_depth.or(&child.backproject_depth).clone(),
             depth_from_world_scale: self
                 .depth_from_world_scale
                 .or(&child.depth_from_world_scale)
@@ -164,7 +155,6 @@ impl EntityProperties {
         Self {
             test_property: other.test_property,
 
-            backproject_depth: other.backproject_depth.or(&self.backproject_depth).clone(),
             depth_from_world_scale: other
                 .depth_from_world_scale
                 .or(&self.depth_from_world_scale)
@@ -185,14 +175,12 @@ impl EntityProperties {
     pub fn has_edits(&self, other: &Self) -> bool {
         let Self {
             test_property,
-            backproject_depth,
             depth_from_world_scale,
             backproject_radius_scale,
             time_series_aggregator,
         } = self;
 
         test_property != &other.test_property
-            || backproject_depth.has_edits(&other.backproject_depth)
             || depth_from_world_scale.has_edits(&other.depth_from_world_scale)
             || backproject_radius_scale.has_edits(&other.backproject_radius_scale)
             || time_series_aggregator.has_edits(&other.time_series_aggregator)

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -1416,41 +1416,21 @@ fn depth_props_ui(
         .latest_at_component_at_closest_ancestor::<PinholeProjection>(entity_path, &query)?
         .0;
 
-    let mut backproject_depth = *entity_props.backproject_depth;
-
-    if ui
-        .re_checkbox(&mut backproject_depth, "Backproject Depth")
-        .on_hover_text(
-            "If enabled, the depth texture will be backprojected into a point cloud rather \
-                than simply displayed as an image.",
-        )
-        .changed()
-    {
-        entity_props.backproject_depth = EditableAutoValue::UserEdited(backproject_depth);
-    }
+    ui.label("Pinhole");
+    item_ui::entity_path_button(
+        ctx.viewer_ctx,
+        &query,
+        db,
+        ui,
+        None,
+        &image_projection_ent_path,
+    )
+    .on_hover_text("The entity path of the pinhole transform being used to do the backprojection.");
     ui.end_row();
 
-    if backproject_depth {
-        ui.label("Pinhole");
-        item_ui::entity_path_button(
-            ctx.viewer_ctx,
-            &query,
-            db,
-            ui,
-            None,
-            &image_projection_ent_path,
-        )
-        .on_hover_text(
-            "The entity path of the pinhole transform being used to do the backprojection.",
-        );
-        ui.end_row();
-
-        depth_from_world_scale_ui(ui, &mut entity_props.depth_from_world_scale);
-
-        backproject_radius_scale_ui(ui, &mut entity_props.backproject_radius_scale);
-
-        colormap_props_ui(ctx, ui, data_result);
-    }
+    depth_from_world_scale_ui(ui, &mut entity_props.depth_from_world_scale);
+    backproject_radius_scale_ui(ui, &mut entity_props.backproject_radius_scale);
+    colormap_props_ui(ctx, ui, data_result);
 
     Some(())
 }

--- a/crates/re_space_view_spatial/src/heuristics.rs
+++ b/crates/re_space_view_spatial/src/heuristics.rs
@@ -21,19 +21,13 @@ use crate::{
 pub fn generate_auto_legacy_properties(
     ctx: &ViewerContext<'_>,
     per_system_entities: &PerSystemEntities,
-    spatial_kind: SpatialSpaceViewKind,
 ) -> re_entity_db::EntityPropertyMap {
     re_tracing::profile_function!();
 
     let mut auto_properties = re_entity_db::EntityPropertyMap::default();
 
     // Do pinhole properties before, since they may be used in transform3d heuristics.
-    update_depth_cloud_property_heuristics(
-        ctx,
-        per_system_entities,
-        &mut auto_properties,
-        spatial_kind,
-    );
+    update_depth_cloud_property_heuristics(ctx, per_system_entities, &mut auto_properties);
 
     auto_properties
 }
@@ -67,7 +61,6 @@ fn update_depth_cloud_property_heuristics(
     ctx: &ViewerContext<'_>,
     per_system_entities: &PerSystemEntities,
     auto_properties: &mut re_entity_db::EntityPropertyMap,
-    spatial_kind: SpatialSpaceViewKind,
 ) {
     // TODO(andreas): There should be a depth cloud system
     for ent_path in per_system_entities
@@ -92,9 +85,6 @@ fn update_depth_cloud_property_heuristics(
             .map(|meter| meter.value.0);
 
         let mut properties = auto_properties.get(ent_path);
-        properties.backproject_depth = EditableAutoValue::Auto(
-            meaning == TensorDataMeaning::Depth && spatial_kind == SpatialSpaceViewKind::ThreeD,
-        );
 
         if meaning == TensorDataMeaning::Depth {
             let auto = meter.unwrap_or_else(|| {

--- a/crates/re_space_view_spatial/src/view_2d.rs
+++ b/crates/re_space_view_spatial/src/view_2d.rs
@@ -162,8 +162,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
         let Ok(_state) = state.downcast_mut::<SpatialSpaceViewState>() else {
             return;
         };
-        *auto_properties =
-            generate_auto_legacy_properties(ctx, ent_paths, SpatialSpaceViewKind::TwoD);
+        *auto_properties = generate_auto_legacy_properties(ctx, ent_paths);
     }
 
     fn spawn_heuristics(

--- a/crates/re_space_view_spatial/src/view_3d.rs
+++ b/crates/re_space_view_spatial/src/view_3d.rs
@@ -355,8 +355,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
         let Ok(_state) = state.downcast_mut::<SpatialSpaceViewState>() else {
             return;
         };
-        *auto_properties =
-            generate_auto_legacy_properties(ctx, ent_paths, SpatialSpaceViewKind::ThreeD);
+        *auto_properties = generate_auto_legacy_properties(ctx, ent_paths);
     }
 
     fn selection_ui(

--- a/crates/re_space_view_spatial/src/visualizers/images.rs
+++ b/crates/re_space_view_spatial/src/visualizers/images.rs
@@ -425,13 +425,15 @@ impl ImageVisualizer {
             return;
         }
 
+        let is_3d_view =
+            ent_context.space_view_class_identifier == SpatialSpaceView3D::identifier();
+
         // Parent pinhole should only be relevant to 3D views
-        let parent_pinhole_path =
-            if ent_context.space_view_class_identifier == SpatialSpaceView3D::identifier() {
-                transforms.parent_pinhole(entity_path)
-            } else {
-                None
-            };
+        let parent_pinhole_path = if is_3d_view {
+            transforms.parent_pinhole(entity_path)
+        } else {
+            None
+        };
 
         let meaning = TensorDataMeaning::Depth;
 
@@ -462,7 +464,7 @@ impl ImageVisualizer {
                 .copied()
                 .unwrap_or_else(|| self.fallback_for(ctx));
 
-            if *ent_props.backproject_depth {
+            if is_3d_view {
                 if let Some(parent_pinhole_path) = transforms.parent_pinhole(entity_path) {
                     // NOTE: we don't pass in `world_from_obj` because this corresponds to the
                     // transform of the projection plane, which is of no use to us here.

--- a/rerun_py/rerun_sdk/rerun/components/colormap.py
+++ b/rerun_py/rerun_sdk/rerun/components/colormap.py
@@ -9,7 +9,11 @@ from typing import Literal, Sequence, Union
 
 import pyarrow as pa
 
-from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+)
 
 __all__ = ["Colormap", "ColormapArrayLike", "ColormapBatch", "ColormapLike", "ColormapType"]
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6550](https://togithub.com/rerun-io/rerun/pull/6550).



The original branch is upstream/andreas/remove-backproject-depth-option