### PR TITLE
Add example for different data per timeline on `Events and Timelines` doc page

### DIFF
--- a/docs/content/concepts/timelines.md
+++ b/docs/content/concepts/timelines.md
@@ -18,6 +18,15 @@ snippet: tutorials/timelines_example
 This will add the logged points to the timelines `log_time`, `frame_idx`, and `sensor_time`.
 You can then choose which timeline you want to organize your data along in the expanded timeline view in the bottom of the Rerun Viewer.
 
+### Reset active timeline & differing data per timeline
+
+You can clear the active timeline(s) at any point using `reset_time`.
+This can be particularly useful when you want to log different data for individual timelines as illustrated here:
+
+snippet: concepts/different_data_per_timeline
+
+On one timeline the points will appear blue, on the other they appear red.
+
 ## Events
 
 An _event_ refer to an instance of logging one or more component batches to one or more timelines. In the viewer, the Time panel provide a graphical representation of these events across time and entities.

--- a/docs/snippets/all/concepts/different_data_per_timeline.cpp
+++ b/docs/snippets/all/concepts/different_data_per_timeline.cpp
@@ -1,0 +1,24 @@
+// Log different data on different timelines.
+
+#include <rerun.hpp>
+
+int main() {
+    const auto rec = rerun::RecordingStream("rerun_example_different_data_per_timeline");
+    rec.spawn().exit_on_failure();
+
+    rec.set_time_sequence("blue timeline", 0);
+    rec.set_time_seconds("red timeline", 0.0);
+    rec.log("points", rerun::Points2D({{0.0, 0.0}, {1.0, 1.0}}));
+
+    // Log a red color on one timeline.
+    rec.reset_time(); // Clears all set timeline info.
+    rec.set_time_seconds("red timeline", 1.0);
+    rec.log("points", std::array{rerun::components::Color(0xFF0000FF)});
+
+    // And a blue color on the other.
+    rec.reset_time(); // Clears all set timeline info.
+    rec.set_time_sequence("blue timeline", 1);
+    rec.log("points", std::array{rerun::components::Color(0x0000FFFF)});
+
+    // TODO(#5521): log VisualBounds2D
+}

--- a/docs/snippets/all/concepts/different_data_per_timeline.py
+++ b/docs/snippets/all/concepts/different_data_per_timeline.py
@@ -1,0 +1,24 @@
+"""Log different data on different timelines."""
+
+import rerun as rr
+import rerun.blueprint as rrb
+
+rr.init("rerun_example_different_data_per_timeline", spawn=True)
+
+rr.set_time_sequence("blue timeline", 0)
+rr.set_time_seconds("red timeline", 0.0)
+rr.log("points", rr.Points2D([[0, 0], [1, 1]], radii=rr.Radius.ui_points(10.0)))
+
+# Log a red color on one timeline.
+rr.reset_time()  # Clears all set timeline info.
+rr.set_time_seconds("red timeline", 1.0)
+rr.log_components("points", [rr.components.Color(0xFF0000FF)])
+
+# And a blue color on the other.
+rr.reset_time()  # Clears all set timeline info.
+rr.set_time_sequence("blue timeline", 1)
+rr.log_components("points", [rr.components.Color(0x0000FFFF)])
+
+
+# Set view bounds:
+rr.send_blueprint(rrb.Spatial2DView(visual_bounds=rrb.VisualBounds2D(x_range=[-1, 2], y_range=[-1, 2])))

--- a/docs/snippets/all/concepts/different_data_per_timeline.rs
+++ b/docs/snippets/all/concepts/different_data_per_timeline.rs
@@ -1,0 +1,24 @@
+//! Log different data on different timelines.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rec =
+        rerun::RecordingStreamBuilder::new("rerun_example_different_data_per_timeline").spawn()?;
+
+    rec.set_time_sequence("blue timeline", 0);
+    rec.set_time_seconds("red timeline", 0.0);
+    rec.log("points", &rerun::Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?;
+
+    // Log a red color on one timeline.
+    rec.reset_time(); // Clears all set timeline info.
+    rec.set_time_seconds("red timeline", 1.0);
+    rec.log("points", &[rerun::components::Color::from_u32(0xFF0000FF)])?;
+
+    // And a blue color on the other.
+    rec.reset_time(); // Clears all set timeline info.
+    rec.set_time_sequence("blue timeline", 1);
+    rec.log("points", &[rerun::components::Color::from_u32(0x0000FFFF)])?;
+
+    // TODO(#5521): log VisualBounds2D
+
+    Ok(())
+}

--- a/docs/snippets/all/concepts/different_data_per_timeline.rs
+++ b/docs/snippets/all/concepts/different_data_per_timeline.rs
@@ -11,12 +11,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Log a red color on one timeline.
     rec.reset_time(); // Clears all set timeline info.
     rec.set_time_seconds("red timeline", 1.0);
-    rec.log("points", &[rerun::components::Color::from_u32(0xFF0000FF)])?;
+    rec.log_component_batches(
+        "points",
+        false,
+        [&rerun::components::Color::from_u32(0xFF0000FF) as &dyn rerun::ComponentBatch],
+    )?;
 
     // And a blue color on the other.
     rec.reset_time(); // Clears all set timeline info.
     rec.set_time_sequence("blue timeline", 1);
-    rec.log("points", &[rerun::components::Color::from_u32(0x0000FFFF)])?;
+    rec.log_component_batches(
+        "points",
+        false,
+        [&rerun::components::Color::from_u32(0x0000FFFF) as &dyn rerun::ComponentBatch],
+    )?;
 
     // TODO(#5521): log VisualBounds2D
 

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -5,7 +5,23 @@
 # You should only ever use this if the test isn't implemented and cannot yet be implemented
 # for one or more specific SDKs.
 [opt_out.run]
-concepts = [
+"concepts/viscomp-base" = [
+  "cpp",  # Blueprint API doesn't exist for C++/Rust
+  "rust", # Blueprint API doesn't exist for C++/Rust
+]
+"concepts/viscomp-component-default" = [
+  "cpp",  # Blueprint API doesn't exist for C++/Rust
+  "rust", # Blueprint API doesn't exist for C++/Rust
+]
+"concepts/viscomp-component-override" = [
+  "cpp",  # Blueprint API doesn't exist for C++/Rust
+  "rust", # Blueprint API doesn't exist for C++/Rust
+]
+"concepts/viscomp-visualizer-override-multiple" = [
+  "cpp",  # Blueprint API doesn't exist for C++/Rust
+  "rust", # Blueprint API doesn't exist for C++/Rust
+]
+"concepts/viscomp-visualizer-override" = [
   "cpp",  # Blueprint API doesn't exist for C++/Rust
   "rust", # Blueprint API doesn't exist for C++/Rust
 ]


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6912](https://togithub.com/rerun-io/rerun/pull/6912).



The original branch is upstream/andreas/different-data-per-timeline-example