### PR TITLE
Fix `Chunk`'s counting routines checking the wrong variable

### DIFF
--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -266,7 +266,7 @@ impl Chunk {
             return vec![(time_range.min(), self.num_events_cumulative() as u64)];
         }
 
-        let counts = if self.is_sorted() {
+        let counts = if time_chunk.is_sorted() {
             self.num_events_cumulative_per_unique_time_sorted(time_chunk)
         } else {
             self.num_events_cumulative_per_unique_time_unsorted(time_chunk)
@@ -286,7 +286,7 @@ impl Chunk {
     ) -> Vec<(TimeInt, u64)> {
         re_tracing::profile_function!();
 
-        debug_assert!(self.is_sorted());
+        debug_assert!(time_chunk.is_sorted());
 
         // NOTE: This is used on some very hot paths (time panel rendering).
         // Performance trumps readability. Optimized empirically.
@@ -335,7 +335,7 @@ impl Chunk {
     ) -> Vec<(TimeInt, u64)> {
         re_tracing::profile_function!();
 
-        debug_assert!(!self.is_sorted());
+        debug_assert!(!time_chunk.is_sorted());
 
         self.components
             .values()

--- a/crates/viewer/re_time_panel/benches/bench_density_graph.rs
+++ b/crates/viewer/re_time_panel/benches/bench_density_graph.rs
@@ -90,8 +90,8 @@ fn add_data(
         log_times.push(time);
 
         if !sorted {
-            let mut rng = rand::thread_rng();
-            use rand::seq::SliceRandom as _;
+            use rand::{seq::SliceRandom as _, SeedableRng as _};
+            let mut rng = rand::rngs::StdRng::seed_from_u64(0xbadf00d);
             log_times.shuffle(&mut rng);
         }
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6936](https://togithub.com/rerun-io/rerun/pull/6936).



The original branch is upstream/cmc/wutsgoingonhere