### PR TITLE
Fix missing early exit in `sorted_by_timeline_if_unsorted`

### DIFF
--- a/crates/store/re_chunk/src/shuffle.rs
+++ b/crates/store/re_chunk/src/shuffle.rs
@@ -99,6 +99,10 @@ impl Chunk {
             return chunk;
         };
 
+        if time_chunk.is_sorted() {
+            return chunk;
+        }
+
         #[cfg(not(target_arch = "wasm32"))]
         let now = std::time::Instant::now();
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6950](https://togithub.com/rerun-io/rerun/pull/6950).



The original branch is upstream/cmc/missing_early_exit