### PR TITLE
Fix: When launched with a file path, the viewer doesn't listen to any TCP ports

### DIFF
--- a/crates/top/rerun/src/run.rs
+++ b/crates/top/rerun/src/run.rs
@@ -918,20 +918,7 @@ fn run_impl(
     };
 
     // Where do we get the data from?
-    let rx: Vec<Receiver<LogMsg>> = if args.url_or_paths.is_empty() {
-        #[cfg(feature = "server")]
-        {
-            let server_options = re_sdk_comms::ServerOptions {
-                max_latency_sec: parse_max_latency(args.drop_at_latency.as_ref()),
-                quiet: false,
-            };
-            let rx = re_sdk_comms::serve(&args.bind, args.port, server_options)?;
-            vec![rx]
-        }
-
-        #[cfg(not(feature = "server"))]
-        vec![]
-    } else {
+    let rx: Vec<Receiver<LogMsg>> = {
         let data_sources = args
             .url_or_paths
             .iter()
@@ -957,10 +944,23 @@ fn run_impl(
             }
         }
 
-        data_sources
+        let mut rxs = data_sources
             .into_iter()
             .map(|data_source| data_source.stream(None))
-            .collect::<Result<Vec<_>, _>>()?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        #[cfg(feature = "server")]
+        {
+            let server_options = re_sdk_comms::ServerOptions {
+                max_latency_sec: parse_max_latency(args.drop_at_latency.as_ref()),
+                quiet: false,
+            };
+            let tcp_listener: Receiver<LogMsg> =
+                re_sdk_comms::serve(&args.bind, args.port, server_options)?;
+            rxs.push(tcp_listener);
+        }
+
+        rxs
     };
 
     // Now what do we do with the data?


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6951](https://togithub.com/rerun-io/rerun/pull/6951).



The original branch is fork-6951-petertheprocess/fix/launch_with_file_and_tcp