### PR TITLE
fix pixi_install_wheel.py for windows & linux-aarch64 not listed in pixi env

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -434,7 +434,7 @@ jobs:
           # It seems to otherwise use the latest commit for the tag. From the actions's docs:
           # > If the tag of the release you are creating does not yet exist, you should set both the tag and commit action inputs.
           # We just deleted the previous tag, so this is the case!
-          commit: ${{ env.SHORT_SHA }}
+          commit: ${{github.sha}}
           name: "Development Build"
           tag: "prerelease"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/rerun_cpp/arrow_cpp_install.md
+++ b/rerun_cpp/arrow_cpp_install.md
@@ -54,7 +54,7 @@ Now, any Pixi tasks added to your project will have access to the `arrow-cpp` li
 Even without tasks, you can run `pixi shell` to create a shell environment where all your project dependencies
 (including `arrow-cpp`) will be available. You can use this `pixi shell` to run you project's build commands.
 
-Check out the [Pixi docs](https://prefix.dev/docs/pixi/basic_usage) for more information on what you can do with Pixi.
+Check out the [Pixi docs](https://pixi.sh/latest/#getting-started) for more information on what you can do with Pixi.
 
 ### Pixi in action
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6960](https://togithub.com/rerun-io/rerun/pull/6960).



The original branch is upstream/andreas/nightly-fixes