### PR TITLE
Fix zero length transform axis having an effect bounding box used for heuristics etc.

### DIFF
--- a/crates/viewer/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -78,16 +78,21 @@ impl VisualizerSystem for Transform3DArrowsVisualizer {
                 continue;
             };
 
+            let results = data_result
+                .latest_at_with_blueprint_resolved_data::<Transform3D>(ctx, &latest_at_query);
+            let axis_length: f32 = results.get_mono_with_fallback::<AxisLength>().into();
+
+            if axis_length == 0.0 {
+                // Don't draw axis and don't add to the bounding box!
+                continue;
+            }
+
             // Only add the center to the bounding box - the lines may be dependent on the bounding box, causing a feedback loop otherwise.
             self.0.add_bounding_box(
                 data_result.entity_path.hash(),
                 re_math::BoundingBox::ZERO,
                 world_from_obj,
             );
-
-            let results = data_result
-                .latest_at_with_blueprint_resolved_data::<Transform3D>(ctx, &latest_at_query);
-            let axis_length = results.get_mono_with_fallback::<AxisLength>().into();
 
             add_axis_arrows(
                 &mut line_builder,


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6967](https://togithub.com/rerun-io/rerun/pull/6967).



The original branch is upstream/andreas/zero-length-transform-axis-handling