### PR TITLE
remove removed `re_data_store` from workspace deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ re_chunk = { path = "crates/store/re_chunk", version = "=0.18.0-alpha.1", defaul
 re_chunk_store = { path = "crates/store/re_chunk_store", version = "=0.18.0-alpha.1", default-features = false }
 re_data_loader = { path = "crates/store/re_data_loader", version = "=0.18.0-alpha.1", default-features = false }
 re_data_source = { path = "crates/store/re_data_source", version = "=0.18.0-alpha.1", default-features = false }
-re_data_store = { path = "crates/store/re_data_store", version = "=0.18.0-alpha.1", default-features = false }
 re_entity_db = { path = "crates/store/re_entity_db", version = "=0.18.0-alpha.1", default-features = false }
 re_format_arrow = { path = "crates/store/re_format_arrow", version = "=0.18.0-alpha.1", default-features = false }
 re_log_encoding = { path = "crates/store/re_log_encoding", version = "=0.18.0-alpha.1", default-features = false }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#6983](https://togithub.com/rerun-io/rerun/pull/6983).



The original branch is upstream/andreas/fix-incorrect-workspace-dependency