### PR TITLE
Revert "add `python-tasks` to `examples` pixi environment"

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -88,13 +88,7 @@ wheel-test = [
 # These environments use the dev version of the python package.
 # The package will be installed in editable mode, so changes to the python code will be reflected immediately.
 # However, any changes to do the rust bindings will require running `pixi run -e examples py-build`.
-examples = [
-  "examples-common",
-  "python-dev",
-  "wheel-build",
-  "python-tasks",
-  "examples-tasks",
-]
+examples = ["examples-common", "python-dev", "wheel-build", "examples-tasks"]
 examples-ocr = ["examples-ocr", "wheel-build"]
 
 # This environment uses the pypi-published version of the python package. This avoids the need to

--- a/pixi.toml
+++ b/pixi.toml
@@ -87,7 +87,7 @@ wheel-test = [
 
 # These environments use the dev version of the python package.
 # The package will be installed in editable mode, so changes to the python code will be reflected immediately.
-# However, any changes to do the rust bindings will require running `pixi run -e examples py-build`.
+# However, any changes to do the rust bindings will require running `pixi run py-build-examples`.
 examples = ["examples-common", "python-dev", "wheel-build", "examples-tasks"]
 examples-ocr = ["examples-ocr", "wheel-build"]
 
@@ -271,8 +271,15 @@ py-build-common = { cmd = "PIP_REQUIRE_VIRTUALENV=0 RERUN_ALLOW_MISSING_BIN=1 ma
   "rerun-build", # We need to build rerun-cli since it is bundled in the python package.
 ] }
 
+# Build the `rerun-notebook` package.
+py-build-notebook = { cmd = "pip install -e rerun_notebook", depends_on = [
+  "js-build-base",
+] }
+
+
 [feature.python-tasks.tasks]
 
+# Dedicated alias for building the python bindings for the `py` environment.
 py-build = "pixi run -e py py-build-common"
 
 # Helper alias to run the python interpreter in the context of the python environment
@@ -286,10 +293,6 @@ py-plot-dashboard = { cmd = "python tests/python/plot_dashboard_stress/main.py",
   "py-build",
 ] }
 
-# Build the `rerun-notebook` package.
-py-build-notebook = { cmd = "pip install -e rerun_notebook", depends_on = [
-  "js-build-base",
-] }
 
 # Run the Python tests.
 # Don't call this on CI - use `nox` to run tests on all supported Python versions instead.
@@ -304,6 +307,8 @@ py-test = { cmd = "python -m pytest -vv rerun_py/tests/unit", depends_on = [
 rerun-from-path = "rerun"
 
 [feature.examples-tasks.tasks]
+
+# Dedicated alias for building the python bindings for the `examples` environment.
 py-build-examples = "pixi run -e examples py-build-common"
 
 # Python example utilities


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [rerun-io/rerun#7007](https://togithub.com/rerun-io/rerun/pull/7007).



The original branch is upstream/revert-6991-andreas/fix-missing-py-commands